### PR TITLE
Resolve build warnings caused by syntax issues in XML doc comments.

### DIFF
--- a/arangodb-net-standard/AnalyzerApi/Models/Analyzer.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/Analyzer.cs
@@ -10,14 +10,14 @@ namespace ArangoDBNetStandard.AnalyzerApi.Models
         /// <summary>
         /// Name of the analyzer
         /// For rules regarding analyzer names, see
-        /// <see cref="https://www.arangodb.com/docs/stable/analyzers.html#analyzer-names"/>
+        /// https://www.arangodb.com/docs/stable/analyzers.html#analyzer-names
         /// </summary>
         public string Name { get; set; }
 
         /// <summary>
         /// Type of the analyzer
         /// For valid analyzer types, see
-        /// <see cref="https://www.arangodb.com/docs/stable/analyzers.html#analyzer-types"/>
+        /// https://www.arangodb.com/docs/stable/analyzers.html#analyzer-types
         /// </summary>
         public string Type { get; set; }
 

--- a/arangodb-net-standard/AnalyzerApi/Models/AnalyzerProperties.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/AnalyzerProperties.cs
@@ -3,8 +3,8 @@
 namespace ArangoDBNetStandard.AnalyzerApi.Models
 {
     /// <summary>
-    /// Properties of an Analyzer
-    /// <see cref="https://www.arangodb.com/docs/stable/analyzers.html#analyzer-properties"/>
+    /// Properties of an Analyzer.
+    /// See https://www.arangodb.com/docs/stable/analyzers.html#analyzer-properties
     /// </summary>
     public class AnalyzerProperties
     {
@@ -52,7 +52,7 @@ namespace ArangoDBNetStandard.AnalyzerApi.Models
         /// treated as a single token, for supported languages.
         /// Stemming support is provided by Snowball,
         /// which supports the languages listed at:
-        /// <see cref="https://www.arangodb.com/docs/stable/analyzers.html#stemming"/>
+        /// https://www.arangodb.com/docs/stable/analyzers.html#stemming
         /// </summary>
         public bool Stemming { get; set; }
     }

--- a/arangodb-net-standard/IndexApi/Models/IndexResponseBase.cs
+++ b/arangodb-net-standard/IndexApi/Models/IndexResponseBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace ArangoDBNetStandard.IndexApi.Models
 {
@@ -102,19 +100,19 @@ namespace ArangoDBNetStandard.IndexApi.Models
 
         /// <summary>
         /// For more information,
-        /// <see cref="https://www.arangodb.com/docs/stable/http/indexes-geo.html"/>
+        /// see https://www.arangodb.com/docs/stable/http/indexes-geo.html
         /// </summary>
         public int? MaxNumCoverCells { get; set; }
 
         /// <summary>
         /// For more information,
-        /// <see cref="https://www.arangodb.com/docs/stable/http/indexes-geo.html"/>
+        /// see https://www.arangodb.com/docs/stable/http/indexes-geo.html
         /// </summary>
         public int? BestIndexedLevel { get; set; }
 
         /// <summary>
         /// For more information,
-        /// <see cref="https://www.arangodb.com/docs/stable/http/indexes-geo.html"/>
+        /// see https://www.arangodb.com/docs/stable/http/indexes-geo.html
         /// </summary>
         public int? WorstIndexedLevel { get; set; }
     }

--- a/arangodb-net-standard/TransactionApi/Models/PostTransactionResponse.cs
+++ b/arangodb-net-standard/TransactionApi/Models/PostTransactionResponse.cs
@@ -13,7 +13,7 @@ namespace ArangoDBNetStandard.TransactionApi.Models
         /// </summary>
         /// <remarks>
         /// Note that in cases where an error occurs, the ArangoDBNetStandard
-        /// client will throw an <see cref="ApiErrorException"> rather than
+        /// client will throw an <see cref="ApiErrorException"/> rather than
         /// populating this property. A try/catch block should be used instead
         /// for any required error handling.
         /// </remarks>


### PR DESCRIPTION
fix #372

The warnings listed on the issue have been resolved.