### PR TITLE
Breaking Change: Renamed CursorResponse to PostCursorResponse

### DIFF
--- a/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
+++ b/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
@@ -316,7 +316,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         [Fact]
         public async Task PutCursorAsync_ShouldReturnResponseModelWithInterface()
         {
-            CursorResponse<int> postResponse =
+            PostCursorResponse<int> postResponse =
                 await _cursorApi.PostCursorAsync<int>("FOR i IN 0..1500 RETURN i");
 
             ICursorResponse<int> putResult =

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -78,7 +78,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="ttl"></param>
         /// <param name="transactionId">Optional. The stream transaction Id.</param>
         /// <returns></returns>
-        public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(
+        public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
                 string query,
                 Dictionary<string, object> bindVars = null,
                 PostCursorOptions options = null,
@@ -115,7 +115,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="postCursorBody">Object encapsulating options and parameters of the query.</param>
         /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <returns></returns>
-        public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(
+        public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
             PostCursorBody postCursorBody, CursorHeaderProperties headerProperties = null)
         {
             var content = GetContent(postCursorBody, new ApiClientSerializationOptions(true, true));
@@ -125,7 +125,7 @@ namespace ArangoDBNetStandard.CursorApi
                 if (response.IsSuccessStatusCode)
                 {
                     var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                    return DeserializeJsonFromStream<CursorResponse<T>>(stream);
+                    return DeserializeJsonFromStream<PostCursorResponse<T>>(stream);
                 }
 
                 throw await GetApiErrorException(response).ConfigureAwait(false);

--- a/arangodb-net-standard/CursorApi/ICursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/ICursorApiClient.cs
@@ -23,7 +23,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="ttl"></param>
         /// <param name="transactionId">Optional. The stream transaction Id.</param>
         /// <returns></returns>
-        Task<CursorResponse<T>> PostCursorAsync<T>(
+        Task<PostCursorResponse<T>> PostCursorAsync<T>(
                 string query,
                 Dictionary<string, object> bindVars = null,
                 PostCursorOptions options = null,
@@ -40,7 +40,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="postCursorBody">Object encapsulating options and parameters of the query.</param>
         /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <returns></returns>
-        Task<CursorResponse<T>> PostCursorAsync<T>(
+        Task<PostCursorResponse<T>> PostCursorAsync<T>(
             PostCursorBody postCursorBody, CursorHeaderProperties headerProperties = null);
 
         /// <summary>

--- a/arangodb-net-standard/CursorApi/Models/PostCursorResponse.cs
+++ b/arangodb-net-standard/CursorApi/Models/PostCursorResponse.cs
@@ -7,7 +7,7 @@ namespace ArangoDBNetStandard.CursorApi.Models
     /// Response from ArangoDB when creating a new cursor.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class CursorResponse<T> : ICursorResponse<T>
+    public class PostCursorResponse<T> : ICursorResponse<T>
     {
         /// <summary>
         /// A flag to indicate that an error occurred (false in this case)


### PR DESCRIPTION
Rename CursorResponse to PostCursorResponse for consistency
Refer to issue #339 