### PR TITLE
Solves NullReferenceException thrown when deserializing empty content of error reponse

### DIFF
--- a/arangodb-net-standard/ApiErrorException.cs
+++ b/arangodb-net-standard/ApiErrorException.cs
@@ -6,6 +6,10 @@ namespace ArangoDBNetStandard
     [Serializable]
     public class ApiErrorException : Exception
     {
+        /// <summary>
+        /// Can be null if ArangoDB returns empty content 
+        /// in the response.
+        /// </summary>
         public ApiErrorResponse ApiError { get; set; }
 
         public ApiErrorException()

--- a/arangodb-net-standard/ApiErrorException.cs
+++ b/arangodb-net-standard/ApiErrorException.cs
@@ -12,7 +12,7 @@ namespace ArangoDBNetStandard
         {
         }
 
-        public ApiErrorException(ApiErrorResponse error) : base(error.ErrorMessage)
+        public ApiErrorException(ApiErrorResponse error) : base(error == null ? string.Empty : error.ErrorMessage)
         {
             ApiError = error;
         }


### PR DESCRIPTION
Solves #320 
Checks for null before accessing the ErrorMessage property