### PR TITLE
Make missing member handling configurable

### DIFF
--- a/arangodb-net-standard/Serialization/ApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/ApiClientSerialization.cs
@@ -12,7 +12,11 @@ namespace ArangoDBNetStandard.Serialization
         /// The default serialization options.
         /// </summary>
         public virtual ApiClientSerializationOptions DefaultOptions { get; } =
-            new ApiClientSerializationOptions(false, true, false, true);
+            new ApiClientSerializationOptions(
+                useCamelCasePropertyNames: false,
+                ignoreNullValues: true,
+                useStringEnumConversion: false,
+                ignoreMissingMember: true);
 
         /// <summary>
         /// Deserializes the data structure contained by the specified stream

--- a/arangodb-net-standard/Serialization/ApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/ApiClientSerialization.cs
@@ -12,7 +12,7 @@ namespace ArangoDBNetStandard.Serialization
         /// The default serialization options.
         /// </summary>
         public virtual ApiClientSerializationOptions DefaultOptions { get; } =
-            new ApiClientSerializationOptions(false, true, false);
+            new ApiClientSerializationOptions(false, true, false, true);
 
         /// <summary>
         /// Deserializes the data structure contained by the specified stream

--- a/arangodb-net-standard/Serialization/ApiClientSerializationOptions.cs
+++ b/arangodb-net-standard/Serialization/ApiClientSerializationOptions.cs
@@ -17,7 +17,7 @@
         public bool IgnoreNullValues { get; set; }
 
         /// <summary>
-        /// True to ignore missing members, otherwise false.
+        /// True to ignore missing members when deserializing, otherwise false.
         /// </summary>
         public bool IgnoreMissingMember { get; set; }
 

--- a/arangodb-net-standard/Serialization/ApiClientSerializationOptions.cs
+++ b/arangodb-net-standard/Serialization/ApiClientSerializationOptions.cs
@@ -17,6 +17,11 @@
         public bool IgnoreNullValues { get; set; }
 
         /// <summary>
+        /// True to ignore missing members, otherwise false.
+        /// </summary>
+        public bool IgnoreMissingMember { get; set; }
+
+        /// <summary>
         /// True to serialize enums to string values, 
         /// false to serialize enums to integer values (default).
         /// </summary>
@@ -28,14 +33,17 @@
         /// <param name="useCamelCasePropertyNames">Whether property names should be serialized using camelCase.</param>
         /// <param name="ignoreNullValues">Whether null values should be ignored - i.e. not defined at all in the serialized string.</param>
         /// <param name="useStringEnumConversion">Whether to serialize enum values to a string value instead of an integer.</param>
+        /// <param name="ignoreMissingMember">Whether missing members should be ignored.</param>
         public ApiClientSerializationOptions(
             bool useCamelCasePropertyNames,
             bool ignoreNullValues,
-            bool useStringEnumConversion = false)
+            bool useStringEnumConversion = false,
+            bool ignoreMissingMember = true)
         {
             UseCamelCasePropertyNames = useCamelCasePropertyNames;
             IgnoreNullValues = ignoreNullValues;
             UseStringEnumConversion = useStringEnumConversion;
+            IgnoreMissingMember = ignoreMissingMember;
         }
     }
 }

--- a/arangodb-net-standard/Serialization/JsonNetApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/JsonNetApiClientSerialization.cs
@@ -71,6 +71,7 @@ namespace ArangoDBNetStandard.Serialization
 
             var jsonSettings = new JsonSerializerSettings
             {
+                MissingMemberHandling = serializationOptions.IgnoreMissingMember ? MissingMemberHandling.Ignore : MissingMemberHandling.Error,
                 NullValueHandling = serializationOptions.IgnoreNullValues ? NullValueHandling.Ignore : NullValueHandling.Include
             };
 

--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,7 @@ The options are passed as an instance of the `ApiClientSerializationOptions` cla
 - `UseCamelCasePropertyNames` (boolean, default is `false`)
 - `IgnoreNullValues` (boolean, default is `true`)
 - `UseStringEnumConversion` (boolean, default is `false`)
+- `IgnoreMissingMember` (boolean, default is `true`)
 
 In addition, the default options can be updated, which will affect all subsequent operations that use these options. To set default options, set them on the serializer implementation itself.  For example, if using the supplied `JsonNetApiClientSerialization`:
 


### PR DESCRIPTION
Solves #213 
- Added ApiClientSerializationOptions.IgnoreMissingMember (true by default)
- Set JsonSerializerSettings.MissingMemberHandling in JsonNetApiClientSerialization based on value in ApiClientSerializationOptions.IgnoreMissingMember  