### PR TITLE
Stream transaction support in the Collection and Graph APIs

### DIFF
--- a/arangodb-net-standard/ApiHeaderProperties.cs
+++ b/arangodb-net-standard/ApiHeaderProperties.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace ArangoDBNetStandard
+{
+    public class ApiHeaderProperties
+    {
+        /// <summary>
+        /// Gets or sets the Id of a stream transaction.
+        /// </summary>
+        public string TransactionId { get; set; }
+
+        /// <summary>
+        /// Any other headers you wish to add based on
+        /// the specifications of the API operation.
+        /// </summary>
+        public Dictionary<string,string> OtherHeaders { get; set; }
+
+        public WebHeaderCollection ToWebHeaderCollection()
+        {
+            WebHeaderCollection collection = new WebHeaderCollection();
+            if (TransactionId != null)
+            {
+                collection.Add(CustomHttpHeaders.StreamTransactionHeader, TransactionId);
+            }
+            if (OtherHeaders != null && OtherHeaders.Count > 0)
+            {
+                foreach (string key in OtherHeaders.Keys)
+                {
+                    collection.Add(key, OtherHeaders[key]); 
+                }
+            }
+            return collection;
+        }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
@@ -88,7 +88,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <param name="collectionName">Name of the collection</param>
         /// <param name="headers">Headers (such as transaction id) to use for this operation.</param>
         /// <returns></returns>
-        public virtual async Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName, ApiHeaderProperties headers = null)
+        public virtual async Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName, CollectionHeaderProperties headers = null)
         {
             using (var response = await _transport.PutAsync(
                 _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/truncate",
@@ -111,7 +111,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <param name="collectionName">Name of the collection</param>
         /// <param name="headers">Headers (such as transaction id) to use for this operation.</param>
         /// <returns></returns>
-        public virtual async Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName, ApiHeaderProperties headers = null)
+        public virtual async Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName, CollectionHeaderProperties headers = null)
         {
             using (var response = await _transport.GetAsync(
                 _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/count", 

--- a/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
@@ -85,13 +85,15 @@ namespace ArangoDBNetStandard.CollectionApi
         /// Truncates a collection, i.e. removes all documents in the collection.
         /// PUT/_api/collection/{collection-name}/truncate
         /// </summary>
-        /// <param name="collectionName"></param>
+        /// <param name="collectionName">Name of the collection</param>
+        /// <param name="headers">Headers (such as transaction id) to use for this operation.</param>
         /// <returns></returns>
-        public virtual async Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName)
+        public virtual async Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName, ApiHeaderProperties headers = null)
         {
             using (var response = await _transport.PutAsync(
                 _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/truncate",
-                new byte[0]).ConfigureAwait(false))
+                new byte[0], 
+                headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -106,11 +108,14 @@ namespace ArangoDBNetStandard.CollectionApi
         /// Gets count of documents in a collection.
         /// GET/_api/collection/{collection-name}/count
         /// </summary>
-        /// <param name="collectionName"></param>
+        /// <param name="collectionName">Name of the collection</param>
+        /// <param name="headers">Headers (such as transaction id) to use for this operation.</param>
         /// <returns></returns>
-        public virtual async Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName)
+        public virtual async Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName, ApiHeaderProperties headers = null)
         {
-            using (var response = await _transport.GetAsync(_collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/count").ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(
+                _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/count", 
+                headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/CollectionApi/ICollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/ICollectionApiClient.cs
@@ -23,7 +23,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <param name="collectionName">Name of the collection</param>
         /// <param name="headers">Headers (such as transaction id) to use for this operation.</param>
         /// <returns></returns>
-        Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName, ApiHeaderProperties headers = null);
+        Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName, CollectionHeaderProperties headers = null);
 
         /// <summary>
         /// Gets count of documents in a collection.
@@ -32,7 +32,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <param name="collectionName">Name of the collection</param>
         /// <param name="headers">Headers (such as transaction id) to use for this operation.</param>
         /// <returns></returns>
-        Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName, ApiHeaderProperties headers = null);
+        Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName, CollectionHeaderProperties headers = null);
 
         /// <summary>
         /// Get all collections.

--- a/arangodb-net-standard/CollectionApi/ICollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/ICollectionApiClient.cs
@@ -20,17 +20,19 @@ namespace ArangoDBNetStandard.CollectionApi
         /// Truncates a collection, i.e. removes all documents in the collection.
         /// PUT/_api/collection/{collection-name}/truncate
         /// </summary>
-        /// <param name="collectionName"></param>
+        /// <param name="collectionName">Name of the collection</param>
+        /// <param name="headers">Headers (such as transaction id) to use for this operation.</param>
         /// <returns></returns>
-        Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName);
+        Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName, ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Gets count of documents in a collection.
         /// GET/_api/collection/{collection-name}/count
         /// </summary>
-        /// <param name="collectionName"></param>
+        /// <param name="collectionName">Name of the collection</param>
+        /// <param name="headers">Headers (such as transaction id) to use for this operation.</param>
         /// <returns></returns>
-        Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName);
+        Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName, ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Get all collections.

--- a/arangodb-net-standard/CollectionApi/Models/CollectionHeaderProperties.cs
+++ b/arangodb-net-standard/CollectionApi/Models/CollectionHeaderProperties.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    /// <summary>
+    /// Provides functionality for collection-specific headers
+    /// </summary>
+    public class CollectionHeaderProperties : ApiHeaderProperties
+    {
+
+    }
+}

--- a/arangodb-net-standard/CursorApi/Models/CursorHeaderProperties.cs
+++ b/arangodb-net-standard/CursorApi/Models/CursorHeaderProperties.cs
@@ -3,11 +3,8 @@
     /// <summary>
     /// Class representing the additional header properties for Cursor Api.
     /// </summary>
-    public class CursorHeaderProperties
+    public class CursorHeaderProperties : ApiHeaderProperties
     {
-        /// <summary>
-        /// Gets or sets the stream transaction Id.
-        /// </summary>
-        public string TransactionId { get; set; }
+
     }
 }

--- a/arangodb-net-standard/DocumentApi/Models/DocumentHeaderProperties.cs
+++ b/arangodb-net-standard/DocumentApi/Models/DocumentHeaderProperties.cs
@@ -2,20 +2,16 @@
 
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
-    public class DocumentHeaderProperties
+    public class DocumentHeaderProperties:ApiHeaderProperties
     {
         public string IfMatch { get; set; }
 
         public string IfNoneMatch { get; set; }
 
-        /// <summary>
-        /// Gets or sets the Id of a stream transaction.
-        /// </summary>
-        public string TransactionId { get; set; }
-
-        public WebHeaderCollection ToWebHeaderCollection()
+        public new WebHeaderCollection ToWebHeaderCollection()
         {
-            WebHeaderCollection collection = new WebHeaderCollection();
+            WebHeaderCollection collection = base.ToWebHeaderCollection();
+            
             if (IfMatch != null)
             {
                 collection.Add(HttpRequestHeader.IfMatch, $"\"{IfMatch}\"");
@@ -24,11 +20,6 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (IfNoneMatch != null)
             {
                 collection.Add(HttpRequestHeader.IfNoneMatch, $"\"{IfNoneMatch}\"");
-            }
-
-            if (TransactionId != null)
-            {
-                collection.Add(CustomHttpHeaders.StreamTransactionHeader, TransactionId);
             }
 
             return collection;

--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -268,7 +268,7 @@ namespace ArangoDBNetStandard.GraphApi
             T vertex,
             PostVertexQuery query = null,
             ApiClientSerializationOptions serializationOptions = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             string uri = _graphApiPath + '/' + WebUtility.UrlEncode(graphName) +
                 "/vertex/" + WebUtility.UrlEncode(collectionName);
@@ -377,7 +377,7 @@ namespace ArangoDBNetStandard.GraphApi
             T edge,
             PostEdgeQuery query = null,
             ApiClientSerializationOptions serializationOptions = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             var content = GetContent(edge, serializationOptions);
 
@@ -415,7 +415,7 @@ namespace ArangoDBNetStandard.GraphApi
             string collectionName,
             string edgeKey,
             GetEdgeQuery query = null,
-           ApiHeaderProperties headers = null)
+           GraphHeaderProperties headers = null)
         {
             return GetEdgeAsync<T>(
                 graphName,
@@ -438,7 +438,7 @@ namespace ArangoDBNetStandard.GraphApi
             string graphName,
             string edgeHandle,
             GetEdgeQuery query = null,
-           ApiHeaderProperties headers = null)
+           GraphHeaderProperties headers = null)
         {
             string uri = _graphApiPath + "/" + WebUtility.UrlEncode(graphName) +
                 "/edge/" + edgeHandle;
@@ -476,7 +476,7 @@ namespace ArangoDBNetStandard.GraphApi
             string collectionName,
             string edgeKey,
             DeleteEdgeQuery query = null,
-           ApiHeaderProperties headers = null)
+           GraphHeaderProperties headers = null)
         {
             return DeleteEdgeAsync<T>(
                 graphName,
@@ -501,7 +501,7 @@ namespace ArangoDBNetStandard.GraphApi
             string graphName,
             string documentId,
             DeleteEdgeQuery query = null,
-           ApiHeaderProperties headers = null)
+           GraphHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -538,7 +538,7 @@ namespace ArangoDBNetStandard.GraphApi
             string collectionName,
             string vertexKey,
             GetVertexQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             return GetVertexAsync<T>(
                 graphName,
@@ -559,7 +559,7 @@ namespace ArangoDBNetStandard.GraphApi
           string graphName,
           string documentId,
           GetVertexQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -596,7 +596,7 @@ namespace ArangoDBNetStandard.GraphApi
             string collectionName,
             string vertexKey,
             DeleteVertexQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             return DeleteVertexAsync<T>(
                 graphName,
@@ -618,7 +618,7 @@ namespace ArangoDBNetStandard.GraphApi
             string graphName,
             string documentId,
             DeleteVertexQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -662,7 +662,7 @@ namespace ArangoDBNetStandard.GraphApi
             string vertexKey,
             T body,
             PatchVertexQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             return PatchVertexAsync<T, U>(
                 graphName,
@@ -691,7 +691,7 @@ namespace ArangoDBNetStandard.GraphApi
             string documentId,
             T body,
             PatchVertexQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -733,7 +733,7 @@ namespace ArangoDBNetStandard.GraphApi
             string edgeKey,
             T edge,
             PutEdgeQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             return PutEdgeAsync<T>(
                 graphName,
@@ -759,7 +759,7 @@ namespace ArangoDBNetStandard.GraphApi
             string documentId,
             T edge,
             PutEdgeQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -839,7 +839,7 @@ namespace ArangoDBNetStandard.GraphApi
             string edgeKey,
             T edge,
             PatchEdgeQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             return PatchEdgeAsync<T, U>(
                 graphName,
@@ -866,7 +866,7 @@ namespace ArangoDBNetStandard.GraphApi
             string documentId,
             T edge,
             PatchEdgeQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -908,7 +908,7 @@ namespace ArangoDBNetStandard.GraphApi
             string key,
             T vertex,
             PutVertexQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             return PutVertexAsync<T>(
                 graphName,
@@ -933,7 +933,7 @@ namespace ArangoDBNetStandard.GraphApi
             string documentId,
             T vertex,
             PutVertexQuery query = null,
-          ApiHeaderProperties headers = null)
+          GraphHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 

--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -260,13 +260,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="query"></param>
         /// <param name="serializationOptions">The serialization options. When the value is null the
         /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<PostVertexResponse<T>> PostVertexAsync<T>(
             string graphName,
             string collectionName,
             T vertex,
             PostVertexQuery query = null,
-            ApiClientSerializationOptions serializationOptions = null)
+            ApiClientSerializationOptions serializationOptions = null,
+          ApiHeaderProperties headers = null)
         {
             string uri = _graphApiPath + '/' + WebUtility.UrlEncode(graphName) +
                 "/vertex/" + WebUtility.UrlEncode(collectionName);
@@ -275,7 +277,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
             var content = GetContent(vertex, serializationOptions);
-            using (var response = await _transport.PostAsync(uri, content).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, content,headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -367,13 +369,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="query">Optional query parameters of the request.</param>
         /// <param name="serializationOptions">The serialization options. When the value is null the
         /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<PostEdgeResponse<T>> PostEdgeAsync<T>(
             string graphName,
             string collectionName,
             T edge,
             PostEdgeQuery query = null,
-            ApiClientSerializationOptions serializationOptions = null)
+            ApiClientSerializationOptions serializationOptions = null,
+          ApiHeaderProperties headers = null)
         {
             var content = GetContent(edge, serializationOptions);
 
@@ -385,7 +389,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
 
-            using (var response = await _transport.PostAsync(uri, content).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, content, headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -404,17 +408,20 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName">The name of the edge collection the edge belongs to.</param>
         /// <param name="edgeKey">The _key attribute of the edge.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual Task<GetEdgeResponse<T>> GetEdgeAsync<T>(
             string graphName,
             string collectionName,
             string edgeKey,
-            GetEdgeQuery query = null)
+            GetEdgeQuery query = null,
+           ApiHeaderProperties headers = null)
         {
             return GetEdgeAsync<T>(
                 graphName,
                 WebUtility.UrlEncode(collectionName) + '/' + WebUtility.UrlEncode(edgeKey),
-                query);
+                query,
+                headers);
         }
 
         /// <summary>
@@ -425,11 +432,13 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="edgeHandle">The document-handle of the edge document.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<GetEdgeResponse<T>> GetEdgeAsync<T>(
             string graphName,
             string edgeHandle,
-            GetEdgeQuery query = null)
+            GetEdgeQuery query = null,
+           ApiHeaderProperties headers = null)
         {
             string uri = _graphApiPath + "/" + WebUtility.UrlEncode(graphName) +
                 "/edge/" + edgeHandle;
@@ -439,7 +448,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
 
-            using (var response = await _transport.GetAsync(uri).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri,headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -460,17 +469,20 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName">The name of the edge collection the edge belongs to.</param>
         /// <param name="edgeKey">The _key attribute of the edge.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual Task<DeleteEdgeResponse<T>> DeleteEdgeAsync<T>(
             string graphName,
             string collectionName,
             string edgeKey,
-            DeleteEdgeQuery query = null)
+            DeleteEdgeQuery query = null,
+           ApiHeaderProperties headers = null)
         {
             return DeleteEdgeAsync<T>(
                 graphName,
                 WebUtility.UrlEncode(collectionName) + "/" + WebUtility.UrlEncode(edgeKey),
-                query);
+                query,
+                headers);
 
         }
 
@@ -483,11 +495,13 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="documentId">The document ID of the edge to delete.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<DeleteEdgeResponse<T>> DeleteEdgeAsync<T>(
             string graphName,
             string documentId,
-            DeleteEdgeQuery query = null)
+            DeleteEdgeQuery query = null,
+           ApiHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -498,7 +512,7 @@ namespace ArangoDBNetStandard.GraphApi
             {
                 uri += "?" + query.ToQueryString();
             }
-            using (var response = await _transport.DeleteAsync(uri).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri,headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -517,12 +531,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName"></param>
         /// <param name="vertexKey"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual Task<GetVertexResponse<T>> GetVertexAsync<T>(
             string graphName,
             string collectionName,
             string vertexKey,
-            GetVertexQuery query = null)
+            GetVertexQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             return GetVertexAsync<T>(
                 graphName,
@@ -537,11 +553,13 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph to get the vertex from.</param>
         /// <param name="documentId">The document ID of the vertex to retrieve.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<GetVertexResponse<T>> GetVertexAsync<T>(
           string graphName,
           string documentId,
-          GetVertexQuery query = null)
+          GetVertexQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -552,7 +570,7 @@ namespace ArangoDBNetStandard.GraphApi
             {
                 uri += "?" + query.ToQueryString();
             }
-            using (var response = await _transport.GetAsync(uri).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri,headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -571,17 +589,20 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName"></param>
         /// <param name="vertexKey"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual Task<DeleteVertexResponse<T>> DeleteVertexAsync<T>(
             string graphName,
             string collectionName,
             string vertexKey,
-            DeleteVertexQuery query = null)
+            DeleteVertexQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             return DeleteVertexAsync<T>(
                 graphName,
                 WebUtility.UrlEncode(collectionName) + "/" + WebUtility.UrlEncode(vertexKey),
-                query);
+                query,
+                headers);
         }
 
         /// <summary>
@@ -591,11 +612,13 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph to delete the vertex from.</param>
         /// <param name="documentId">The document ID of the vertex to delete.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<DeleteVertexResponse<T>> DeleteVertexAsync<T>(
             string graphName,
             string documentId,
-            DeleteVertexQuery query = null)
+            DeleteVertexQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -607,7 +630,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
 
-            using (var response = await _transport.DeleteAsync(uri).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri,headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -631,19 +654,22 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="vertexKey"></param>
         /// <param name="body"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual Task<PatchVertexResponse<U>> PatchVertexAsync<T, U>(
             string graphName,
             string collectionName,
             string vertexKey,
             T body,
-            PatchVertexQuery query = null)
+            PatchVertexQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             return PatchVertexAsync<T, U>(
                 graphName,
                 WebUtility.UrlEncode(collectionName) + "/" + WebUtility.UrlEncode(vertexKey),
                 body,
-                query);
+                query,
+                headers);
         }
 
         /// <summary>
@@ -658,12 +684,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="documentId">The document ID of the vertex to update.</param>
         /// <param name="body"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<PatchVertexResponse<U>> PatchVertexAsync<T, U>(
             string graphName,
             string documentId,
             T body,
-            PatchVertexQuery query = null)
+            PatchVertexQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -676,7 +704,7 @@ namespace ArangoDBNetStandard.GraphApi
             }
 
             var content = GetContent(body, new ApiClientSerializationOptions(false, false));
-            using (var response = await _transport.PatchAsync(uri, content).ConfigureAwait(false))
+            using (var response = await _transport.PatchAsync(uri, content,headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -697,19 +725,22 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edgeKey"></param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual Task<PutEdgeResponse<T>> PutEdgeAsync<T>(
             string graphName,
             string collectionName,
             string edgeKey,
             T edge,
-            PutEdgeQuery query = null)
+            PutEdgeQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             return PutEdgeAsync<T>(
                 graphName,
                 WebUtility.UrlEncode(collectionName) + "/" + WebUtility.UrlEncode(edgeKey),
                 edge,
-                query);
+                query,
+                headers);
         }
 
         /// <summary>
@@ -721,12 +752,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="documentId">The document ID of the edge to replace.</param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<PutEdgeResponse<T>> PutEdgeAsync<T>(
             string graphName,
             string documentId,
             T edge,
-            PutEdgeQuery query = null)
+            PutEdgeQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -739,7 +772,7 @@ namespace ArangoDBNetStandard.GraphApi
             }
 
             var content = GetContent(edge, new ApiClientSerializationOptions(false, false));
-            using (var response = await _transport.PutAsync(uri, content).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uri, content, headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -798,19 +831,22 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edgeKey">The document key of the edge to update.</param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual Task<PatchEdgeResponse<U>> PatchEdgeAsync<T, U>(
             string graphName,
             string collectionName,
             string edgeKey,
             T edge,
-            PatchEdgeQuery query = null)
+            PatchEdgeQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             return PatchEdgeAsync<T, U>(
                 graphName,
                 WebUtility.UrlEncode(collectionName) + "/" + WebUtility.UrlEncode(edgeKey),
                 edge,
-                query);
+                query,
+                headers);
         }
 
         /// <summary>
@@ -823,12 +859,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="documentId">The document ID of the edge to update.</param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<PatchEdgeResponse<U>> PatchEdgeAsync<T, U>(
             string graphName,
             string documentId,
             T edge,
-            PatchEdgeQuery query = null)
+            PatchEdgeQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -841,7 +879,7 @@ namespace ArangoDBNetStandard.GraphApi
             }
 
             var content = GetContent(edge, new ApiClientSerializationOptions(true, true));
-            using (var response = await _transport.PatchAsync(uri, content).ConfigureAwait(false))
+            using (var response = await _transport.PatchAsync(uri, content, headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -862,19 +900,22 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="key"></param>
         /// <param name="vertex"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual Task<PutVertexResponse<T>> PutVertexAsync<T>(
             string graphName,
             string collectionName,
             string key,
             T vertex,
-            PutVertexQuery query = null)
+            PutVertexQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             return PutVertexAsync<T>(
                 graphName,
                 WebUtility.UrlEncode(collectionName) + "/" + WebUtility.UrlEncode(key),
                 vertex,
-                query);
+                query,
+                headers);
         }
 
         /// <summary>
@@ -885,12 +926,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="documentId">The document ID of the vertex to replace.</param>
         /// <param name="vertex"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         public virtual async Task<PutVertexResponse<T>> PutVertexAsync<T>(
             string graphName,
             string documentId,
             T vertex,
-            PutVertexQuery query = null)
+            PutVertexQuery query = null,
+          ApiHeaderProperties headers = null)
         {
             ValidateDocumentId(documentId);
 
@@ -903,7 +946,7 @@ namespace ArangoDBNetStandard.GraphApi
             }
 
             var content = GetContent(vertex, new ApiClientSerializationOptions(true, true));
-            using (var response = await _transport.PutAsync(uri, content).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uri, content, headers?.ToWebHeaderCollection()).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/GraphApi/IGraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/IGraphApiClient.cs
@@ -117,7 +117,7 @@ namespace ArangoDBNetStandard.GraphApi
           T vertex,
           PostVertexQuery query = null,
           ApiClientSerializationOptions serializationOptions = null,
-          ApiHeaderProperties headers=null);
+          GraphHeaderProperties headers=null);
 
         /// <summary>
         /// Remove one edge definition from the graph. This will only remove the
@@ -174,7 +174,7 @@ namespace ArangoDBNetStandard.GraphApi
           T edge,
           PostEdgeQuery query = null,
           ApiClientSerializationOptions serializationOptions = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Gets an edge from the given graph using the edge collection and _key attribute.
@@ -191,7 +191,7 @@ namespace ArangoDBNetStandard.GraphApi
            string collectionName,
            string edgeKey,
            GetEdgeQuery query = null,
-           ApiHeaderProperties headers = null);
+           GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Gets an edge from the given graph using the edge's document-handle.
@@ -207,7 +207,7 @@ namespace ArangoDBNetStandard.GraphApi
           string graphName,
           string edgeHandle,
           GetEdgeQuery query = null,
-           ApiHeaderProperties headers = null);
+           GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Removes an edge from the collection.
@@ -226,7 +226,7 @@ namespace ArangoDBNetStandard.GraphApi
           string collectionName,
           string edgeKey,
           DeleteEdgeQuery query = null,
-           ApiHeaderProperties headers = null);
+           GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Removes an edge based on its document ID.
@@ -242,7 +242,7 @@ namespace ArangoDBNetStandard.GraphApi
           string graphName,
           string documentId,
           DeleteEdgeQuery query = null,
-           ApiHeaderProperties headers = null);
+           GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Gets a vertex from the given collection.
@@ -259,7 +259,7 @@ namespace ArangoDBNetStandard.GraphApi
           string collectionName,
           string vertexKey,
           GetVertexQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Gets a vertex based on its document ID.
@@ -273,7 +273,7 @@ namespace ArangoDBNetStandard.GraphApi
           string graphName,
           string documentId,
           GetVertexQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Removes a vertex from the collection.
@@ -290,7 +290,7 @@ namespace ArangoDBNetStandard.GraphApi
           string collectionName,
           string vertexKey,
           DeleteVertexQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Removes a vertex based on its document ID.
@@ -304,7 +304,7 @@ namespace ArangoDBNetStandard.GraphApi
           string graphName,
           string documentId,
           DeleteVertexQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Updates the data of the specific vertex in the collection.
@@ -327,7 +327,7 @@ namespace ArangoDBNetStandard.GraphApi
           string vertexKey,
           T body,
           PatchVertexQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Updates the data of the specific vertex based on its document ID.
@@ -347,7 +347,7 @@ namespace ArangoDBNetStandard.GraphApi
           string documentId,
           T body,
           PatchVertexQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Replaces the data of an edge in the collection.
@@ -367,7 +367,7 @@ namespace ArangoDBNetStandard.GraphApi
           string edgeKey,
           T edge,
           PutEdgeQuery query = null,
-          ApiHeaderProperties headers=null);
+          GraphHeaderProperties headers=null);
 
         /// <summary>
         /// Replaces the data of an edge based on its document ID.
@@ -384,7 +384,7 @@ namespace ArangoDBNetStandard.GraphApi
           string documentId,
           T edge,
           PutEdgeQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Change one specific edge definition.
@@ -422,7 +422,7 @@ namespace ArangoDBNetStandard.GraphApi
           string edgeKey,
           T edge,
           PatchEdgeQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Updates the data of the specific edge based on its document ID.
@@ -441,7 +441,7 @@ namespace ArangoDBNetStandard.GraphApi
           string documentId,
           T edge,
           PatchEdgeQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Replaces the data of a vertex in the collection.
@@ -461,7 +461,7 @@ namespace ArangoDBNetStandard.GraphApi
           string key,
           T vertex,
           PutVertexQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
 
         /// <summary>
         /// Replaces the data of a vertex based on its document ID.
@@ -478,6 +478,6 @@ namespace ArangoDBNetStandard.GraphApi
           string documentId,
           T vertex,
           PutVertexQuery query = null,
-          ApiHeaderProperties headers = null);
+          GraphHeaderProperties headers = null);
     }
 }

--- a/arangodb-net-standard/GraphApi/IGraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/IGraphApiClient.cs
@@ -109,13 +109,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="query"></param>
         /// <param name="serializationOptions">The serialization options. When the value is null the
         /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PostVertexResponse<T>> PostVertexAsync<T>(
           string graphName,
           string collectionName,
           T vertex,
           PostVertexQuery query = null,
-          ApiClientSerializationOptions serializationOptions = null);
+          ApiClientSerializationOptions serializationOptions = null,
+          ApiHeaderProperties headers=null);
 
         /// <summary>
         /// Remove one edge definition from the graph. This will only remove the
@@ -163,14 +165,16 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edge">The edge to create.</param>
         /// <param name="query"></param>
         /// <param name="serializationOptions">The serialization options. When the value is null the
-        /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>
+        /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>        
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PostEdgeResponse<T>> PostEdgeAsync<T>(
           string graphName,
           string collectionName,
           T edge,
           PostEdgeQuery query = null,
-          ApiClientSerializationOptions serializationOptions = null);
+          ApiClientSerializationOptions serializationOptions = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Gets an edge from the given graph using the edge collection and _key attribute.
@@ -179,13 +183,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="collectionName">The name of the edge collection the edge belongs to.</param>
         /// <param name="edgeKey">The _key attribute of the edge.</param>
-        /// <param name="query"></param>
+        /// <param name="query"></param>   
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<GetEdgeResponse<T>> GetEdgeAsync<T>(
            string graphName,
            string collectionName,
            string edgeKey,
-           GetEdgeQuery query = null);
+           GetEdgeQuery query = null,
+           ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Gets an edge from the given graph using the edge's document-handle.
@@ -195,11 +201,13 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="edgeHandle">The document-handle of the edge document.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<GetEdgeResponse<T>> GetEdgeAsync<T>(
           string graphName,
           string edgeHandle,
-          GetEdgeQuery query = null);
+          GetEdgeQuery query = null,
+           ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Removes an edge from the collection.
@@ -211,12 +219,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName">The name of the edge collection the edge belongs to.</param>
         /// <param name="edgeKey">The _key attribute of the edge.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<DeleteEdgeResponse<T>> DeleteEdgeAsync<T>(
           string graphName,
           string collectionName,
           string edgeKey,
-          DeleteEdgeQuery query = null);
+          DeleteEdgeQuery query = null,
+           ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Removes an edge based on its document ID.
@@ -226,11 +236,13 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="documentId">The document ID of the edge to delete.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<DeleteEdgeResponse<T>> DeleteEdgeAsync<T>(
           string graphName,
           string documentId,
-          DeleteEdgeQuery query = null);
+          DeleteEdgeQuery query = null,
+           ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Gets a vertex from the given collection.
@@ -240,12 +252,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName"></param>
         /// <param name="vertexKey"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<GetVertexResponse<T>> GetVertexAsync<T>(
           string graphName,
           string collectionName,
           string vertexKey,
-          GetVertexQuery query = null);
+          GetVertexQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Gets a vertex based on its document ID.
@@ -253,11 +267,13 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph to get the vertex from.</param>
         /// <param name="documentId">The document ID of the vertex to retrieve.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<GetVertexResponse<T>> GetVertexAsync<T>(
           string graphName,
           string documentId,
-          GetVertexQuery query = null);
+          GetVertexQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Removes a vertex from the collection.
@@ -267,12 +283,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName"></param>
         /// <param name="vertexKey"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<DeleteVertexResponse<T>> DeleteVertexAsync<T>(
           string graphName,
           string collectionName,
           string vertexKey,
-          DeleteVertexQuery query = null);
+          DeleteVertexQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Removes a vertex based on its document ID.
@@ -280,11 +298,13 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph to delete the vertex from.</param>
         /// <param name="documentId">The document ID of the vertex to delete.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<DeleteVertexResponse<T>> DeleteVertexAsync<T>(
           string graphName,
           string documentId,
-          DeleteVertexQuery query = null);
+          DeleteVertexQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Updates the data of the specific vertex in the collection.
@@ -299,13 +319,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="vertexKey"></param>
         /// <param name="body"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PatchVertexResponse<U>> PatchVertexAsync<T, U>(
           string graphName,
           string collectionName,
           string vertexKey,
           T body,
-          PatchVertexQuery query = null);
+          PatchVertexQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Updates the data of the specific vertex based on its document ID.
@@ -318,12 +340,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="documentId">The document ID of the vertex to update.</param>
         /// <param name="body"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PatchVertexResponse<U>> PatchVertexAsync<T, U>(
           string graphName,
           string documentId,
           T body,
-          PatchVertexQuery query = null);
+          PatchVertexQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Replaces the data of an edge in the collection.
@@ -335,13 +359,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edgeKey"></param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PutEdgeResponse<T>> PutEdgeAsync<T>(
           string graphName,
           string collectionName,
           string edgeKey,
           T edge,
-          PutEdgeQuery query = null);
+          PutEdgeQuery query = null,
+          ApiHeaderProperties headers=null);
 
         /// <summary>
         /// Replaces the data of an edge based on its document ID.
@@ -351,12 +377,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="documentId">The document ID of the edge to replace.</param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PutEdgeResponse<T>> PutEdgeAsync<T>(
           string graphName,
           string documentId,
           T edge,
-          PutEdgeQuery query = null);
+          PutEdgeQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Change one specific edge definition.
@@ -386,13 +414,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edgeKey">The document key of the edge to update.</param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PatchEdgeResponse<U>> PatchEdgeAsync<T, U>(
           string graphName,
           string collectionName,
           string edgeKey,
           T edge,
-          PatchEdgeQuery query = null);
+          PatchEdgeQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Updates the data of the specific edge based on its document ID.
@@ -404,12 +434,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="documentId">The document ID of the edge to update.</param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PatchEdgeResponse<U>> PatchEdgeAsync<T, U>(
           string graphName,
           string documentId,
           T edge,
-          PatchEdgeQuery query = null);
+          PatchEdgeQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Replaces the data of a vertex in the collection.
@@ -421,13 +453,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="key"></param>
         /// <param name="vertex"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PutVertexResponse<T>> PutVertexAsync<T>(
           string graphName,
           string collectionName,
           string key,
           T vertex,
-          PutVertexQuery query = null);
+          PutVertexQuery query = null,
+          ApiHeaderProperties headers = null);
 
         /// <summary>
         /// Replaces the data of a vertex based on its document ID.
@@ -437,11 +471,13 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="documentId">The document ID of the vertex to replace.</param>
         /// <param name="vertex"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers to use for this operation.</param>
         /// <returns></returns>
         Task<PutVertexResponse<T>> PutVertexAsync<T>(
           string graphName,
           string documentId,
           T vertex,
-          PutVertexQuery query = null);
+          PutVertexQuery query = null,
+          ApiHeaderProperties headers = null);
     }
 }

--- a/arangodb-net-standard/GraphApi/Models/GraphHeaderProperties.cs
+++ b/arangodb-net-standard/GraphApi/Models/GraphHeaderProperties.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ArangoDBNetStandard.GraphApi.Models
+{
+    /// <summary>
+    /// Provides functionality for graph-specific headers
+    /// </summary>
+    public class GraphHeaderProperties : ApiHeaderProperties
+    {
+
+    }
+}


### PR DESCRIPTION
Solves issue #328 
- Added ApiHeaderProperties allowing users to pass any header (as long as it is supported) to a method. This will be useful for situations in the future where the API adds new headers and we have not had the time to add named properties/parameters for these new headers in the driver.
- Added stream transaction support in the Collection and Graph APIs