### PR TITLE
Added support for satellite graphs in graph API

### DIFF
--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -54,7 +54,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <remarks>
         /// The creation of a graph requires the name of the graph and a definition of its edges.
         /// </remarks>
-        /// <param name="postGraphBody">The information of the graph to create.</param>
+        /// <param name="postGraphBody">The information of the graph to create. Must be an instance of <see cref="PostSatelliteGraphOptions"/> or <see cref="PostNonSatelliteGraphOptions"/>.</param>
         /// <param name="query">Optional query parameters of the request.</param>
         /// <returns></returns>
         public virtual async Task<PostGraphResponse> PostGraphAsync(

--- a/arangodb-net-standard/GraphApi/Models/PostGraphBody.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostGraphBody.cs
@@ -35,7 +35,18 @@ namespace ArangoDBNetStandard.GraphApi.Models
         public bool? IsSmart { get; set; }
 
         /// <summary>
+        /// (Optional) Whether to create a Disjoint SmartGraph instead 
+        /// of a regular SmartGraph (Enterprise Edition only).
+        /// </summary>
+        /// <remarks>
+        /// (cluster only)
+        /// </remarks>
+        public bool? IsDisjoint { get; set; }
+
+        /// <summary>
         /// (Optional) Defines options for creating collections within this graph.
+        /// Must be an instance of <see cref="PostSatelliteGraphOptions"/> or
+        /// <see cref="PostNonSatelliteGraphOptions"/>
         /// </summary>
         public PostGraphOptions Options { get; set; }
     }

--- a/arangodb-net-standard/GraphApi/Models/PostGraphBody.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostGraphBody.cs
@@ -6,7 +6,8 @@ namespace ArangoDBNetStandard.GraphApi.Models
     /// Represents a request body to create a named graph.
     /// </summary>
     /// <remarks>
-    /// The creation of a graph requires the name of the graph and a definition of its edges.
+    /// The creation of a graph requires the name of the graph
+    /// and a definition of its edges.
     /// </remarks>
     public class PostGraphBody
     {

--- a/arangodb-net-standard/GraphApi/Models/PostGraphOptions.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostGraphOptions.cs
@@ -1,9 +1,11 @@
-﻿namespace ArangoDBNetStandard.GraphApi.Models
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.GraphApi.Models
 {
     /// <summary>
     /// Defines options for creating collections within a graph.
     /// </summary>
-    public class PostGraphOptions
+    public abstract class PostGraphOptions
     {
         /// <summary>
         /// The attribute name that is used to smartly shard the vertices of a graph.
@@ -18,6 +20,15 @@
         public string SmartGraphAttribute { get; set; }
 
         /// <summary>
+        /// (Optional) An array of collection names that will be used 
+        /// to create SatelliteCollections for a 
+        /// Hybrid (Disjoint) SmartGraph (Enterprise Edition only). 
+        /// Each array element must be a string and a valid collection name. 
+        /// The collection type cannot be modified later.
+        /// </summary>
+        public IEnumerable<string> Satellites { get; set; }
+
+        /// <summary>
         /// The number of shards that is used for every collection within this graph.
         /// Cannot be modified later.
         /// </summary>
@@ -27,12 +38,18 @@
         public int NumberOfShards { get; set; }
 
         /// <summary>
-        /// The replication factor used when initially creating collections for this graph
-        /// (Enterprise Edition only).
+        /// Write concern for new collections in the graph.
+        /// It determines how many copies of each shard are 
+        /// required to be in sync on the different DB-Servers. 
+        /// If there are less then these many copies in the cluster
+        /// a shard will refuse to write. Writes to shards with
+        /// enough up-to-date copies will succeed at the same time however. 
+        /// The value of writeConcern can not be larger than 
+        /// <see cref="PostNonSatelliteGraphOptions.ReplicationFactor"/>.
         /// </summary>
         /// <remarks>
         /// (cluster only)
         /// </remarks>
-        public int ReplicationFactor { get; set; }
+        public int? WriteConcern { get; set; }
     }
 }

--- a/arangodb-net-standard/GraphApi/Models/PostGraphOptions.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostGraphOptions.cs
@@ -27,29 +27,5 @@ namespace ArangoDBNetStandard.GraphApi.Models
         /// The collection type cannot be modified later.
         /// </summary>
         public IEnumerable<string> Satellites { get; set; }
-
-        /// <summary>
-        /// The number of shards that is used for every collection within this graph.
-        /// Cannot be modified later.
-        /// </summary>
-        /// <remarks>
-        /// (cluster only)
-        /// </remarks>
-        public int NumberOfShards { get; set; }
-
-        /// <summary>
-        /// Write concern for new collections in the graph.
-        /// It determines how many copies of each shard are 
-        /// required to be in sync on the different DB-Servers. 
-        /// If there are less then these many copies in the cluster
-        /// a shard will refuse to write. Writes to shards with
-        /// enough up-to-date copies will succeed at the same time however. 
-        /// The value of writeConcern can not be larger than 
-        /// <see cref="PostNonSatelliteGraphOptions.ReplicationFactor"/>.
-        /// </summary>
-        /// <remarks>
-        /// (cluster only)
-        /// </remarks>
-        public int? WriteConcern { get; set; }
     }
 }

--- a/arangodb-net-standard/GraphApi/Models/PostNonSatelliteGraphOptions.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostNonSatelliteGraphOptions.cs
@@ -1,0 +1,17 @@
+﻿namespace ArangoDBNetStandard.GraphApi.Models
+{
+    /// <summary>
+    /// Options to create a non-satellite graph.
+    /// </summary>
+    public class PostNonSatelliteGraphOptions : PostGraphOptions
+    {
+        /// <summary>
+        /// The replication factor used when initially creating collections for this graph
+        /// (Enterprise Edition only).
+        /// </summary>
+        /// <remarks>
+        /// (cluster only)
+        /// </remarks>
+        public int ReplicationFactor { get; set; }
+    }
+}

--- a/arangodb-net-standard/GraphApi/Models/PostNonSatelliteGraphOptions.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostNonSatelliteGraphOptions.cs
@@ -13,5 +13,29 @@
         /// (cluster only)
         /// </remarks>
         public int ReplicationFactor { get; set; }
+
+        /// <summary>
+        /// The number of shards that is used for every collection within this graph.
+        /// Cannot be modified later.
+        /// </summary>
+        /// <remarks>
+        /// (cluster only)
+        /// </remarks>
+        public int NumberOfShards { get; set; }
+
+        /// <summary>
+        /// Write concern for new collections in the graph.
+        /// It determines how many copies of each shard are 
+        /// required to be in sync on the different DB-Servers. 
+        /// If there are less then these many copies in the cluster
+        /// a shard will refuse to write. Writes to shards with
+        /// enough up-to-date copies will succeed at the same time however. 
+        /// The value of writeConcern can not be larger than 
+        /// <see cref="ReplicationFactor"/>.
+        /// </summary>
+        /// <remarks>
+        /// (cluster only)
+        /// </remarks>
+        public int? WriteConcern { get; set; }
     }
 }

--- a/arangodb-net-standard/GraphApi/Models/PostSatelliteGraphOptions.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostSatelliteGraphOptions.cs
@@ -6,10 +6,9 @@
     public class PostSatelliteGraphOptions : PostGraphOptions
     {
         /// <summary>
-        ///  Set to "satellite" to create a SatelliteGraph,
-        ///  which will ignore numberOfShards, minReplicationFactor
-        ///  and writeConcern (Enterprise Edition only).
+        ///  Always set to "satellite" to create 
+        ///  a SatelliteGraph (Enterprise Edition only).
         /// </summary>
-        public string ReplicationFactor { get; set; }
+        public string ReplicationFactor { get; } = "satellite";
     }
 }

--- a/arangodb-net-standard/GraphApi/Models/PostSatelliteGraphOptions.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostSatelliteGraphOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace ArangoDBNetStandard.GraphApi.Models
+{
+    /// <summary>
+    /// Options to create a satellite graph.
+    /// </summary>
+    public class PostSatelliteGraphOptions : PostGraphOptions
+    {
+        /// <summary>
+        ///  Set to "satellite" to create a SatelliteGraph,
+        ///  which will ignore numberOfShards, minReplicationFactor
+        ///  and writeConcern (Enterprise Edition only).
+        /// </summary>
+        public string ReplicationFactor { get; set; }
+    }
+}


### PR DESCRIPTION
Solves issue #306 
- Added PostSatelliteGraphOptions and PostNonSatelliteGraphOptions inheriting from PostGraphOptions.
- Declared PostGraphOptions abstract so it cannot be instantiated. This is a breaking change!
- Added IsDisjoint to PostGraphBody
- Added WriteConcern and Satellites to PostGraphOptions