### PR TITLE
HTTP Status Code #411

### DIFF
--- a/arangodb-net-standard/ApiClientBase.cs
+++ b/arangodb-net-standard/ApiClientBase.cs
@@ -29,8 +29,9 @@ namespace ArangoDBNetStandard
         {
             try
             {
-                if (response.Content.Headers.ContentType?.MediaType?.Contains("json",
-                        StringComparison.InvariantCultureIgnoreCase) ?? false)
+                string mediaType = response.Content.Headers.ContentType?.MediaType;
+                if (mediaType != null && mediaType.IndexOf("json",
+                        StringComparison.InvariantCultureIgnoreCase) >= 0)
                 {
                     var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                     var error = _serialization.DeserializeFromStream<ApiErrorResponse>(stream);


### PR DESCRIPTION
There is a case when the HTTP response body does not contain a valid JSON. In that case it is useful to return to the client the HTTP Status code.