### PR TITLE
3.10: Deprecate fulltext index option

### DIFF
--- a/arangodb-net-standard/IndexApi/Models/IndexTypes.cs
+++ b/arangodb-net-standard/IndexApi/Models/IndexTypes.cs
@@ -1,4 +1,6 @@
-﻿namespace ArangoDBNetStandard.IndexApi.Models
+﻿using System;
+
+namespace ArangoDBNetStandard.IndexApi.Models
 {
     /// <summary>
     /// Defines values for ArangoDB index types.
@@ -6,8 +8,11 @@
     public static class IndexTypes
     {
         /// <summary>
-        /// See https://www.arangodb.com/docs/stable/http/indexes-fulltext.html
+        /// This option is deprecated.
+        /// For an alternative to fulltext indexes
+        /// see https://www.arangodb.com/docs/stable/arangosearch.html
         /// </summary>
+        [Obsolete("Use ArangoSearch for advanced full-text search capabilities.")]
         public const string FullText = "fulltext";
 
         /// <summary>


### PR DESCRIPTION
Marked fulltext option as Obsolete indicating the recommendation to use ArangoSearch for fulltext searching.
See https://github.com/arangodb/docs/blob/main/3.10/release-notes-upgrading-changes310.md#indexes