### PR TITLE
3.10: Added Read From Follower support

### DIFF
--- a/arangodb-net-standard/ApiHeaderProperties.cs
+++ b/arangodb-net-standard/ApiHeaderProperties.cs
@@ -13,6 +13,11 @@ namespace ArangoDBNetStandard
         public string TransactionId { get; set; }
 
         /// <summary>
+        /// Allow read from followers
+        /// </summary>
+        public bool? AllowReadFromFollowers { get; set; }
+
+        /// <summary>
         /// Any other headers you wish to add based on
         /// the specifications of the API operation.
         /// </summary>
@@ -25,6 +30,12 @@ namespace ArangoDBNetStandard
             {
                 collection.Add(CustomHttpHeaders.StreamTransactionHeader, TransactionId);
             }
+
+            if (AllowReadFromFollowers != null)
+            {
+                collection.Add(CustomHttpHeaders.ReadFromFollowersHeader, AllowReadFromFollowers.Value.ToString());
+            }
+
             if (OtherHeaders != null && OtherHeaders.Count > 0)
             {
                 foreach (string key in OtherHeaders.Keys)
@@ -32,6 +43,7 @@ namespace ArangoDBNetStandard
                     collection.Add(key, OtherHeaders[key]); 
                 }
             }
+
             return collection;
         }
     }

--- a/arangodb-net-standard/ApiHeaderProperties.cs
+++ b/arangodb-net-standard/ApiHeaderProperties.cs
@@ -13,7 +13,7 @@ namespace ArangoDBNetStandard
         public string TransactionId { get; set; }
 
         /// <summary>
-        /// Allow read from followers
+        /// Allow read from followers ("dirty reads").
         /// </summary>
         public bool? AllowReadFromFollowers { get; set; }
 

--- a/arangodb-net-standard/ApiHeaderProperties.cs
+++ b/arangodb-net-standard/ApiHeaderProperties.cs
@@ -14,6 +14,7 @@ namespace ArangoDBNetStandard
 
         /// <summary>
         /// Allow read from followers ("dirty reads").
+        /// Introduced in ArangoDB 3.10.
         /// </summary>
         public bool? AllowReadFromFollowers { get; set; }
 

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -109,7 +109,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// Execute an AQL query, creating a cursor which can be used to page query results.
         /// </summary>
         /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
+        /// This method supports Read from Followers (dirty-reads) introduced in ArangoDB 3.10. 
         /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <param name="postCursorBody">Object encapsulating options and parameters of the query.</param>

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -59,10 +59,6 @@ namespace ArangoDBNetStandard.CursorApi
         /// <summary>
         /// Execute an AQL query, creating a cursor which can be used to page query results.
         /// </summary>
-        /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
-        /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="query"></param>
         /// <param name="bindVars"></param>
@@ -73,7 +69,6 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="memoryLimit"></param>
         /// <param name="ttl"></param>
         /// <param name="transactionId">Optional. The stream transaction Id.</param>
-        /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
@@ -86,14 +81,9 @@ namespace ArangoDBNetStandard.CursorApi
                 long? memoryLimit = null,
                 int? ttl = null,
                 string transactionId = null,
-                CursorHeaderProperties headerProperties = null,
             CancellationToken token = default)
         {
-            if (headerProperties == null)
-            {
-                headerProperties = new CursorHeaderProperties();
-            }
-
+            var headerProperties = new CursorHeaderProperties();
             if (!string.IsNullOrWhiteSpace(transactionId))
             {
                 headerProperties.TransactionId = transactionId;
@@ -127,7 +117,8 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
-            PostCursorBody postCursorBody, CursorHeaderProperties headerProperties = null,
+            PostCursorBody postCursorBody, 
+            CursorHeaderProperties headerProperties = null,
             CancellationToken token = default)
         {
             var content = GetContent(postCursorBody, new ApiClientSerializationOptions(true, true));

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -53,21 +53,16 @@ namespace ArangoDBNetStandard.CursorApi
         /// <returns><see cref="WebHeaderCollection"/> values.</returns>
         protected virtual WebHeaderCollection GetHeaderCollection(CursorHeaderProperties headerProperties)
         {
-            var headerCollection = new WebHeaderCollection();
-            if (headerProperties != null)
-            {
-                if (!string.IsNullOrWhiteSpace(headerProperties.TransactionId))
-                {
-                    headerCollection.Add(CustomHttpHeaders.StreamTransactionHeader, headerProperties.TransactionId);
-                }
-            }
-
-            return headerCollection;
+            return headerProperties?.ToWebHeaderCollection(); 
         }
 
         /// <summary>
         /// Execute an AQL query, creating a cursor which can be used to page query results.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="query"></param>
         /// <param name="bindVars"></param>
@@ -78,6 +73,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="memoryLimit"></param>
         /// <param name="ttl"></param>
         /// <param name="transactionId">Optional. The stream transaction Id.</param>
+        /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
@@ -90,9 +86,14 @@ namespace ArangoDBNetStandard.CursorApi
                 long? memoryLimit = null,
                 int? ttl = null,
                 string transactionId = null,
+                CursorHeaderProperties headerProperties = null,
             CancellationToken token = default)
         {
-            var headerProperties = new CursorHeaderProperties();
+            if (headerProperties == null)
+            {
+                headerProperties = new CursorHeaderProperties();
+            }
+
             if (!string.IsNullOrWhiteSpace(transactionId))
             {
                 headerProperties.TransactionId = transactionId;
@@ -117,6 +118,10 @@ namespace ArangoDBNetStandard.CursorApi
         /// <summary>
         /// Execute an AQL query, creating a cursor which can be used to page query results.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <param name="postCursorBody">Object encapsulating options and parameters of the query.</param>
         /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -68,7 +68,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="cache"></param>
         /// <param name="memoryLimit"></param>
         /// <param name="ttl"></param>
-        /// <param name="transactionId">Optional. The stream transaction Id.</param>
+        /// <param name="transactionId">Optional. The stream transaction Id.</param>      
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
@@ -110,7 +110,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// </summary>
         /// <remarks>
         /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <param name="postCursorBody">Object encapsulating options and parameters of the query.</param>
         /// <param name="headerProperties">Optional. Additional Header properties.</param>

--- a/arangodb-net-standard/CursorApi/ICursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/ICursorApiClient.cs
@@ -13,6 +13,10 @@ namespace ArangoDBNetStandard.CursorApi
         /// <summary>
         /// Execute an AQL query, creating a cursor which can be used to page query results.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="query"></param>
         /// <param name="bindVars"></param>
@@ -22,7 +26,8 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="cache"></param>
         /// <param name="memoryLimit"></param>
         /// <param name="ttl"></param>
-        /// <param name="transactionId">Optional. The stream transaction Id.</param>
+        /// <param name="transactionId">Optional. The stream transaction Id.</param>        
+        /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PostCursorResponse<T>> PostCursorAsync<T>(
@@ -35,11 +40,16 @@ namespace ArangoDBNetStandard.CursorApi
                 long? memoryLimit = null,
                 int? ttl = null,
                 string transactionId = null,
+                CursorHeaderProperties headerProperties = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Execute an AQL query, creating a cursor which can be used to page query results.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <param name="postCursorBody">Object encapsulating options and parameters of the query.</param>
         /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>

--- a/arangodb-net-standard/CursorApi/ICursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/ICursorApiClient.cs
@@ -13,10 +13,6 @@ namespace ArangoDBNetStandard.CursorApi
         /// <summary>
         /// Execute an AQL query, creating a cursor which can be used to page query results.
         /// </summary>
-        /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
-        /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="query"></param>
         /// <param name="bindVars"></param>
@@ -26,8 +22,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="cache"></param>
         /// <param name="memoryLimit"></param>
         /// <param name="ttl"></param>
-        /// <param name="transactionId">Optional. The stream transaction Id.</param>        
-        /// <param name="headerProperties">Optional. Additional Header properties.</param>
+        /// <param name="transactionId">Optional. The stream transaction Id.</param>      
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PostCursorResponse<T>> PostCursorAsync<T>(
@@ -40,7 +35,6 @@ namespace ArangoDBNetStandard.CursorApi
                 long? memoryLimit = null,
                 int? ttl = null,
                 string transactionId = null,
-                CursorHeaderProperties headerProperties = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -48,7 +42,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// </summary>
         /// <remarks>
         /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <param name="postCursorBody">Object encapsulating options and parameters of the query.</param>
         /// <param name="headerProperties">Optional. Additional Header properties.</param>

--- a/arangodb-net-standard/CursorApi/ICursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/ICursorApiClient.cs
@@ -41,7 +41,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// Execute an AQL query, creating a cursor which can be used to page query results.
         /// </summary>
         /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
+        /// This method supports Read from Followers (dirty-reads) introduced in ArangoDB 3.10. 
         /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <param name="postCursorBody">Object encapsulating options and parameters of the query.</param>

--- a/arangodb-net-standard/CustomHttpHeaders.cs
+++ b/arangodb-net-standard/CustomHttpHeaders.cs
@@ -11,6 +11,7 @@
         public const string StreamTransactionHeader = "x-arango-trx-id";
         /// <summary>
         /// The header string used for Allowing Read From Followers (dirty-reads)
+        /// Introduced in ArangoDB 3.10.
         /// </summary>    
         public const string ReadFromFollowersHeader = "x-arango-allow-dirty-read";
     }

--- a/arangodb-net-standard/CustomHttpHeaders.cs
+++ b/arangodb-net-standard/CustomHttpHeaders.cs
@@ -9,5 +9,9 @@
         /// The header string used for Stream Transaction.
         /// </summary>    
         public const string StreamTransactionHeader = "x-arango-trx-id";
+        /// <summary>
+        /// The header string used for Allowing Read From Followers (dirty-reads)
+        /// </summary>    
+        public const string ReadFromFollowersHeader = "x-arango-allow-dirty-read";
     }
 }

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -300,6 +300,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <summary>
         /// Get an existing document.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="collectionName"></param>
         /// <param name="documentKey"></param>
@@ -320,6 +324,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <summary>
         /// Get an existing document based on its Document ID.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="documentId"></param>
         /// <param name="headers">The <see cref="DocumentHeaderProperties"/> values.</param>
@@ -346,6 +354,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <summary>
         /// Get multiple documents.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <typeparam name="T">The type of the documents
         /// deserialized from the response.</typeparam>
         /// <param name="collectionName">Collection name</param>

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -301,8 +301,8 @@ namespace ArangoDBNetStandard.DocumentApi
         /// Get an existing document.
         /// </summary>
         /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// This method supports Read from Followers (dirty-reads). Introduced in ArangoDB 3.10.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="collectionName"></param>
@@ -325,8 +325,8 @@ namespace ArangoDBNetStandard.DocumentApi
         /// Get an existing document based on its Document ID.
         /// </summary>
         /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// This method supports Read from Followers (dirty-reads). Introduced in ArangoDB 3.10.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="documentId"></param>
@@ -355,8 +355,8 @@ namespace ArangoDBNetStandard.DocumentApi
         /// Get multiple documents.
         /// </summary>
         /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// This method supports Read from Followers (dirty-reads). Introduced in ArangoDB 3.10.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <typeparam name="T">The type of the documents
         /// deserialized from the response.</typeparam>

--- a/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
@@ -143,8 +143,8 @@ namespace ArangoDBNetStandard.DocumentApi
         /// Get an existing document.
         /// </summary>
         /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// This method supports Read from Followers (dirty-reads). Introduced in ArangoDB 3.10.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="collectionName"></param>
@@ -159,8 +159,8 @@ namespace ArangoDBNetStandard.DocumentApi
         /// Get an existing document based on its Document ID.
         /// </summary>
         /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// This method supports Read from Followers (dirty-reads). Introduced in ArangoDB 3.10.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="documentId"></param>
@@ -174,8 +174,8 @@ namespace ArangoDBNetStandard.DocumentApi
         /// Get multiple documents.
         /// </summary>
         /// <remarks>
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// This method supports Read from Followers (dirty-reads). Introduced in ArangoDB 3.10.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <typeparam name="T">The type of the documents
         /// deserialized from the response.</typeparam>

--- a/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
@@ -142,6 +142,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <summary>
         /// Get an existing document.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="collectionName"></param>
         /// <param name="documentKey"></param>
@@ -154,6 +158,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <summary>
         /// Get an existing document based on its Document ID.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="documentId"></param>
         /// <param name="headers">The <see cref="DocumentHeaderProperties"/> values.</param>
@@ -165,6 +173,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <summary>
         /// Get multiple documents.
         /// </summary>
+        /// <remarks>
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// </remarks>
         /// <typeparam name="T">The type of the documents
         /// deserialized from the response.</typeparam>
         /// <param name="collectionName">Collection name</param>

--- a/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
@@ -30,15 +30,20 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </summary>
         /// <remarks>
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#begin-a-transaction
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
         /// </remarks>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 10 if the <paramref name="body"/> is missing or malformed.
         /// With ErrorNum 1203 if the <paramref name="body"/> contains an unknown collection.
         /// </exception>
         /// <returns>Response from ArangoDB after beginning a transaction.</returns>
-        Task<StreamTransactionResponse> BeginTransaction(StreamTransactionBody body,
+        Task<StreamTransactionResponse> BeginTransaction(
+            StreamTransactionBody body,
+            ApiHeaderProperties headerProperties = null,
             CancellationToken token = default);
 
         /// <summary>

--- a/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
@@ -30,8 +30,8 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </summary>
         /// <remarks>
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#begin-a-transaction
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// This method supports Read from Followers (dirty-reads). Introduced in ArangoDB 3.10.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -114,8 +114,8 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </summary>
         /// <remarks>
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#begin-a-transaction
-        /// This method supports Read from Followers (dirty-reads). 
-        /// To enable it, set the AllowReadFromFollowers header property to true.
+        /// This method supports Read from Followers (dirty-reads). Introduced in ArangoDB 3.10.
+        /// To enable it, set the <see cref="ApiHeaderProperties.AllowReadFromFollowers"/> header property to true.
         /// </remarks>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
         /// <param name="headerProperties">Optional. Additional Header properties.</param>

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using ArangoDBNetStandard.CursorApi.Models;
 using ArangoDBNetStandard.Serialization;
 using ArangoDBNetStandard.TransactionApi.Models;
 using ArangoDBNetStandard.Transport;
@@ -113,20 +114,29 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </summary>
         /// <remarks>
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#begin-a-transaction
+        /// This method supports Read from Followers (dirty-reads). 
+        /// To enable it, set the AllowReadFromFollowers header property to true.
         /// </remarks>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
+        /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 10 if the <paramref name="body"/> is missing or malformed.
         /// With ErrorNum 1203 if the <paramref name="body"/> contains an unknown collection.
         /// </exception>
         /// <returns>Response from ArangoDB after beginning a transaction.</returns>
-        public virtual async Task<StreamTransactionResponse> BeginTransaction(StreamTransactionBody body,
+        public virtual async Task<StreamTransactionResponse> BeginTransaction(
+            StreamTransactionBody body,
+            ApiHeaderProperties headerProperties = null,
             CancellationToken token = default)
         {
             var content = GetContent(body, new ApiClientSerializationOptions(true, true));
             string beginTransactionPath = string.Format(_streamTransactionApiPath, "begin");
-            using (var response = await _client.PostAsync(beginTransactionPath, content, token: token).ConfigureAwait(false))
+            using (var response = await _client.PostAsync(
+                beginTransactionPath,
+                content,
+                webHeaderCollection: headerProperties?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)


### PR DESCRIPTION
Added Read From Follower support to the following:
- Single document reads (GET /_api/document)
- Batch document reads (PUT /_api/document?onlyget=true)
- Read-only AQL queries (POST /_api/cursor)
- Read-only Stream Transactions and their sub-operations (POST /_api/transaction/begin)

See also https://github.com/arangodb/docs/blob/main/3.10/release-notes-api-changes310.md#read-from-followers