### PR TITLE
3.10: Consolidation of new 3.10 index features

### DIFF
--- a/arangodb-net-standard.Test/IndexApi/IndexApiClientTest.cs
+++ b/arangodb-net-standard.Test/IndexApi/IndexApiClientTest.cs
@@ -58,6 +58,7 @@ namespace ArangoDBNetStandardTest.IndexApi
             string indexId = createResponse.Id;
             Assert.False(createResponse.Error);
             Assert.NotNull(indexId);
+            Assert.True(createResponse.Unique);
         }
 
         [Fact]

--- a/arangodb-net-standard.Test/IndexApi/IndexApiClientTest.cs
+++ b/arangodb-net-standard.Test/IndexApi/IndexApiClientTest.cs
@@ -39,7 +39,7 @@ namespace ArangoDBNetStandardTest.IndexApi
         }
 
         [Fact]
-        public async Task PostIndexAsync_ShouldSucceed()
+        public async Task PostPersistentIndexAsync_ShouldSucceed()
         {
             var createResponse = await _indexApi.PostPersistentIndexAsync(
                  new PostIndexQuery()

--- a/arangodb-net-standard.Test/IndexApi/IndexApiClientTest.cs
+++ b/arangodb-net-standard.Test/IndexApi/IndexApiClientTest.cs
@@ -41,14 +41,13 @@ namespace ArangoDBNetStandardTest.IndexApi
         [Fact]
         public async Task PostIndexAsync_ShouldSucceed()
         {
-            var createResponse = await _indexApi.PostIndexAsync(
+            var createResponse = await _indexApi.PostPersistentIndexAsync(
                  new PostIndexQuery()
                  {
                      CollectionName = _testCollection,
                  },
-                 new PostIndexBody()
+                 new PostPersistentIndexBody()
                  {
-                     Type = IndexTypes.Persistent,
                      Fields = new string[]
                      {
                           "field1",
@@ -59,25 +58,6 @@ namespace ArangoDBNetStandardTest.IndexApi
             string indexId = createResponse.Id;
             Assert.False(createResponse.Error);
             Assert.NotNull(indexId);
-        }
-
-        [Fact]
-        public async Task PostIndexAsync_ShouldThrow_WhenIndexTypeIsInvalid()
-        {
-            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
-            {
-                await _indexApi.PostIndexAsync(
-                    new PostIndexQuery()
-                    {
-                        CollectionName = _testCollection
-                    },
-                    new PostIndexBody()
-                    {
-                        Type = "unknownindextype"
-                    });
-            });
-            Assert.Equal(HttpStatusCode.BadRequest, ex.ApiError.Code);
-            Assert.Equal(10, ex.ApiError.ErrorNum);
         }
 
         [Fact]
@@ -129,14 +109,13 @@ namespace ArangoDBNetStandardTest.IndexApi
         public async Task DeleteIndexAsync_ShouldSucceed()
         {
             //Create the index first
-            var createResponse = await _indexApi.PostIndexAsync(
+            var createResponse = await _indexApi.PostPersistentIndexAsync(
                  new PostIndexQuery()
                  {
                      CollectionName = _testCollection,
                  },
-                 new PostIndexBody()
+                 new PostPersistentIndexBody ()
                  {
-                     Type = IndexTypes.Persistent,
                      Fields = new string[]
                      {
                           "field1",

--- a/arangodb-net-standard.Test/IndexApi/IndexApiClientTestFixture.cs
+++ b/arangodb-net-standard.Test/IndexApi/IndexApiClientTestFixture.cs
@@ -32,14 +32,13 @@ namespace ArangoDBNetStandardTest.IndexApi
                 new PostCollectionBody() { Name = TestCollectionName });
 
             Console.WriteLine("Collection " + TestCollectionName + " created successfully");
-            var idxRes = await ArangoDBClient.Index.PostIndexAsync(
+            var idxRes = await ArangoDBClient.Index.PostPersistentIndexAsync(
                 new PostIndexQuery()
                 {
                     CollectionName = TestCollectionName,
                 },
-                new PostIndexBody()
+                new PostPersistentIndexBody()
                 {
-                    Type = IndexTypes.Persistent,
                     Name = TestIndexName,
                     Fields = new string[] { "TestName" },
                     Unique = true

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponseIndex.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponseIndex.cs
@@ -44,5 +44,18 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
 
         public List<string> StoredValues { get; set; }
         public bool? CacheEnabled { get; set; }
+
+        /// <summary>
+        /// Introduced in v3.10.
+        /// A geo index with legacyPolygons set to true
+        /// will use the old, pre-3.10 rules for the parsing
+        /// GeoJSON polygons. This allows you to let old 
+        /// indexes produce the same, potentially wrong 
+        /// results as before an upgrade. A geo index with
+        /// legacyPolygons set to false will use the new, 
+        /// correct and consistent method for parsing of
+        /// GeoJSON polygons.
+        /// </summary>
+        public bool? LegacyPolygons { get; set; }
     }
 }

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponseIndex.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponseIndex.cs
@@ -41,5 +41,8 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         public int? BestIndexedLevel { get; set; }
 
         public int? WorstIndexedLevel { get; set; }
+
+        public List<string> StoredValues { get; set; }
+        public bool? CacheEnabled { get; set; }
     }
 }

--- a/arangodb-net-standard/IndexApi/IIndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IIndexApiClient.cs
@@ -81,12 +81,17 @@ namespace ArangoDBNetStandard.IndexApi
             CancellationToken token = default);
 
         /// <summary>
-        /// Creates a new hash index
+        /// Creates a new hash index.
+        /// Deprecated in v3.9.
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
+        /// <remarks>
+        /// Deprecated in v3.9.
+        /// </remarks>
+        [Obsolete("A hash index is now an alias for a persistent index. Use PostPersistentIndexAsync().")]
         Task<IndexResponseBase> PostHashIndexAsync(PostIndexQuery query,
             PostHashIndexBody body,
             CancellationToken token = default);
@@ -114,12 +119,17 @@ namespace ArangoDBNetStandard.IndexApi
             CancellationToken token = default);
 
         /// <summary>
-        /// Creates a new skiplist index
+        /// Creates a new skiplist index.
+        /// Deprecated in v3.9.
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
+        /// <remarks>
+        /// Deprecated in v3.9.
+        /// </remarks>
+        [Obsolete("A hash index is now an alias for a persistent index. Use PostPersistentIndexAsync().")]
         Task<IndexResponseBase> PostSkiplistIndexAsync(PostIndexQuery query,
             PostSkiplistIndexBody body,
             CancellationToken token = default);

--- a/arangodb-net-standard/IndexApi/IIndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IIndexApiClient.cs
@@ -1,4 +1,6 @@
-﻿using ArangoDBNetStandard.IndexApi.Models;
+﻿
+using ArangoDBNetStandard.IndexApi.Models;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,13 +39,85 @@ namespace ArangoDBNetStandard.IndexApi
             CancellationToken token = default);
 
         /// <summary>
-        /// Creates a new index
+        /// Creates a new fulltext index.
+        /// Deprecated in v3.10.
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<IndexResponseBase> PostIndexAsync(PostIndexQuery query, PostIndexBody body,
+        /// <remarks>
+        /// Deprecated in v3.10.
+        /// </remarks>
+        [Obsolete("Use ArangoSearch for advanced full-text search capabilities.")]
+        Task<IndexResponseBase> PostFulltextIndexAsync(PostIndexQuery query,
+            PostFulltextIndexBody body,
+            CancellationToken token = default);
+
+        /// <summary>
+        /// Creates a new geo-spatial index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        Task<IndexResponseBase> PostGeoSpatialIndexAsync(PostIndexQuery query,
+            PostGeoSpatialIndexBody body,
+            CancellationToken token = default);
+
+        /// <summary>
+        /// Creates a new hash index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        Task<IndexResponseBase> PostHashIndexAsync(PostIndexQuery query,
+            PostHashIndexBody body,
+            CancellationToken token = default);
+
+        /// <summary>
+        /// Creates a new multi-dimensional index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        Task<IndexResponseBase> PostMultiDimensionalIndexAsync(PostIndexQuery query,
+            PostMultiDimensionalIndexBody body,
+            CancellationToken token = default);
+
+        /// <summary>
+        /// Creates a new persistent index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        Task<IndexResponseBase> PostPersistentIndexAsync(PostIndexQuery query,
+            PostPersistentIndexBody body,
+            CancellationToken token = default);
+
+        /// <summary>
+        /// Creates a new skiplist index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        Task<IndexResponseBase> PostSkiplistIndexAsync(PostIndexQuery query,
+            PostSkiplistIndexBody body,
+            CancellationToken token = default);
+
+        /// <summary>
+        /// Creates a new TTL (time-to-live) index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        Task<IndexResponseBase> PostTTLIndexAsync(PostIndexQuery query,
+            PostTTLIndexBody body,
             CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/IndexApi/IIndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IIndexApiClient.cs
@@ -119,5 +119,16 @@ namespace ArangoDBNetStandard.IndexApi
         Task<IndexResponseBase> PostTTLIndexAsync(PostIndexQuery query,
             PostTTLIndexBody body,
             CancellationToken token = default);
+
+        /// <summary>
+        /// Creates a new inverted index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        Task<IndexResponseBase> PostInvertedIndexAsync(PostIndexQuery query,
+            PostInvertedIndexBody body,
+            CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/IndexApi/IIndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IIndexApiClient.cs
@@ -39,6 +39,21 @@ namespace ArangoDBNetStandard.IndexApi
             CancellationToken token = default);
 
         /// <summary>
+        /// Generic method to create an index.
+        /// It is highly recommended that you use a specialized method like
+        /// <see cref="PostGeoSpatialIndexAsync(PostIndexQuery, PostGeoSpatialIndexBody, CancellationToken)"/>
+        /// to create indexes. Use this method to create indexes that do not
+        /// have a specialized method available.
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>       
+        Task<IndexResponseBase> PostIndexAsync(PostIndexQuery query,
+            PostIndexBody body,
+            CancellationToken token = default);
+
+        /// <summary>
         /// Creates a new fulltext index.
         /// Deprecated in v3.10.
         /// </summary>

--- a/arangodb-net-standard/IndexApi/IndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IndexApiClient.cs
@@ -204,12 +204,17 @@ namespace ArangoDBNetStandard.IndexApi
         }
 
         /// <summary>
-        /// Creates a new hash index
+        /// Creates a new hash index.
+        /// Deprecated in v3.9.
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
+        /// <remarks>
+        /// Deprecated in v3.9.
+        /// </remarks>
+        [Obsolete("A hash index is now an alias for a persistent index. Use PostPersistentIndexAsync().")]
         public virtual async Task<IndexResponseBase> PostHashIndexAsync(PostIndexQuery query,
             PostHashIndexBody body,
             CancellationToken token = default)
@@ -246,12 +251,17 @@ namespace ArangoDBNetStandard.IndexApi
         }
 
         /// <summary>
-        /// Creates a new skiplist index
+        /// Creates a new skiplist index.
+        /// Deprecated in v3.9.
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
+        /// <remarks>
+        /// Deprecated in v3.9.
+        /// </remarks>
+        [Obsolete("A hash index is now an alias for a persistent index. Use PostPersistentIndexAsync().")]
         public virtual async Task<IndexResponseBase> PostSkiplistIndexAsync(PostIndexQuery query,
             PostSkiplistIndexBody body,
             CancellationToken token = default)

--- a/arangodb-net-standard/IndexApi/IndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IndexApiClient.cs
@@ -263,5 +263,17 @@ namespace ArangoDBNetStandard.IndexApi
         {
             return await PostIndexAsync(query, body, token).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Creates a new inverted index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        public virtual async Task<IndexResponseBase> PostInvertedIndexAsync(PostIndexQuery query, PostInvertedIndexBody body, CancellationToken token = default)
+        {
+            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+        }
     }
 }

--- a/arangodb-net-standard/IndexApi/IndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IndexApiClient.cs
@@ -124,10 +124,19 @@ namespace ArangoDBNetStandard.IndexApi
                 throw await GetApiErrorException(response).ConfigureAwait(false);
             }
         }
-                
-        /// <inheritdoc/>
-        /// <exception cref="System.ArgumentException">Required parameters not provided or invalid.</exception> 
-        protected virtual async Task<IndexResponseBase> PostIndexAsync(PostIndexQuery query, 
+
+        /// <summary>
+        /// Generic method to create an index.
+        /// It is highly recommended that you use a specialized method like
+        /// <see cref="PostGeoSpatialIndexAsync(PostIndexQuery, PostGeoSpatialIndexBody, CancellationToken)"/>
+        /// to create indexes. Use this method to create indexes that do not
+        /// have a specialized method available.
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>  
+        public virtual async Task<IndexResponseBase> PostIndexAsync(PostIndexQuery query, 
             PostIndexBody body,
             CancellationToken token = default)
         {

--- a/arangodb-net-standard/IndexApi/IndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IndexApiClient.cs
@@ -5,6 +5,7 @@ using ArangoDBNetStandard.Serialization;
 using ArangoDBNetStandard.Transport;
 using ArangoDBNetStandard.IndexApi.Models;
 using System.Threading;
+using System;
 
 namespace ArangoDBNetStandard.IndexApi
 {
@@ -126,7 +127,8 @@ namespace ArangoDBNetStandard.IndexApi
                 
         /// <inheritdoc/>
         /// <exception cref="System.ArgumentException">Required parameters not provided or invalid.</exception> 
-        public virtual async Task<IndexResponseBase> PostIndexAsync(PostIndexQuery query, PostIndexBody body,
+        protected virtual async Task<IndexResponseBase> PostIndexAsync(PostIndexQuery query, 
+            PostIndexBody body,
             CancellationToken token = default)
         {
             string uri = _indexApiPath;
@@ -157,6 +159,109 @@ namespace ArangoDBNetStandard.IndexApi
                 }
                 throw await GetApiErrorException(response).ConfigureAwait(false);
             }
+        }
+
+        /// <summary>
+        /// Creates a new fulltext index.
+        /// Deprecated in v3.10.
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Deprecated in v3.10.
+        /// </remarks>
+        [Obsolete("Use ArangoSearch for advanced full-text search capabilities.")]
+        public virtual async Task<IndexResponseBase> PostFulltextIndexAsync(PostIndexQuery query,
+            PostFulltextIndexBody body,
+            CancellationToken token = default)
+        {
+            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new geo-spatial index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        public virtual async Task<IndexResponseBase> PostGeoSpatialIndexAsync(PostIndexQuery query,
+            PostGeoSpatialIndexBody body,
+            CancellationToken token = default)
+        {
+            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new hash index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        public virtual async Task<IndexResponseBase> PostHashIndexAsync(PostIndexQuery query,
+            PostHashIndexBody body,
+            CancellationToken token = default)
+        {
+            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new multi-dimensional index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        public virtual async Task<IndexResponseBase> PostMultiDimensionalIndexAsync(PostIndexQuery query,
+            PostMultiDimensionalIndexBody body,
+            CancellationToken token = default)
+        {
+            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new persistent index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        public virtual async Task<IndexResponseBase> PostPersistentIndexAsync(PostIndexQuery query,
+            PostPersistentIndexBody body,
+            CancellationToken token = default)
+        {
+            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new skiplist index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        public virtual async Task<IndexResponseBase> PostSkiplistIndexAsync(PostIndexQuery query,
+            PostSkiplistIndexBody body,
+            CancellationToken token = default)
+        {
+            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new TTL (time-to-live) index
+        /// </summary>
+        /// <param name="query">Query parameters for the request.</param>
+        /// <param name="body">The properties of the new index.</param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        public virtual async Task<IndexResponseBase> PostTTLIndexAsync(PostIndexQuery query,
+            PostTTLIndexBody body,
+            CancellationToken token = default)
+        {
+            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
         }
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/IIndexResponse.cs
+++ b/arangodb-net-standard/IndexApi/Models/IIndexResponse.cs
@@ -113,5 +113,18 @@ namespace ArangoDBNetStandard.IndexApi.Models
         /// index values for persistent indexes.
         /// </summary>
         bool? CacheEnabled { get; set; }
+
+        /// <summary>
+        /// Introduced in v3.10.
+        /// A geo index with legacyPolygons set to true
+        /// will use the old, pre-3.10 rules for the parsing
+        /// GeoJSON polygons. This allows you to let old 
+        /// indexes produce the same, potentially wrong 
+        /// results as before an upgrade. A geo index with
+        /// legacyPolygons set to false will use the new, 
+        /// correct and consistent method for parsing of
+        /// GeoJSON polygons.
+        /// </summary>
+        bool? LegacyPolygons { get; set; }
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/IIndexResponse.cs
+++ b/arangodb-net-standard/IndexApi/Models/IIndexResponse.cs
@@ -24,10 +24,7 @@ namespace ArangoDBNetStandard.IndexApi.Models
         IEnumerable<string> Fields { get; set; }
 
         /// <summary>
-        /// Applies to indexes of type <see cref="IndexTypes.Persistent"/>.
         /// Indicates whether the index is a sparse index or not.
-        /// Sparse indexes do not index documents for which any of the index attributes
-        /// is either not set or is null.
         /// </summary>
         bool? Sparse { get; set; }
 
@@ -38,19 +35,10 @@ namespace ArangoDBNetStandard.IndexApi.Models
 
         /// <summary>
         /// Indicates whether the index is a unique or non-unique index.
-        /// Sparse indexes do not index documents for which any of the index attributes
-        /// is either not set or is null.
         /// </summary>
-        /// <remarks>
-        /// The following index types do not support uniqueness,
-        /// and using the unique attribute with these types may lead to an error:
-        /// <see cref="IndexTypes.Geo"/>, <see cref="IndexTypes.FullText"/>.
-        /// Unique indexes on non-shard keys are not supported in a cluster.
-        /// </remarks>
         bool? Unique { get; set; }
 
         /// <summary>
-        /// Supported by indexes of type <see cref="IndexTypes.Persistent"/>.
         /// Indicates whether index selectivity estimates are maintained for the index.
         /// </summary>
         bool? Estimates { get; set; }
@@ -61,16 +49,13 @@ namespace ArangoDBNetStandard.IndexApi.Models
         double? SelectivityEstimate { get; set; }
 
         /// <summary>
-        /// Supported by array indexes of type <see cref="IndexTypes.Persistent"/>. 
         /// Indicates whether inserting duplicate index values from the same document
         /// into a unique array index will lead to a unique constraint error or not.
         /// </summary>
         bool? Deduplicate { get; set; }
 
         /// <summary>
-        /// Supported by indexes of type <see cref="IndexTypes.Geo"/>.
-        /// If a geo-spatial index on a location is constructed and geoJson is true,
-        /// then the order within the array is longitude followed by latitude.
+        /// Is Geo Json enabled/disabled for the index.
         /// </summary>
         /// <remarks>
         /// This corresponds to the format described in http://geojson.org/geojson-spec.html#positions
@@ -78,7 +63,6 @@ namespace ArangoDBNetStandard.IndexApi.Models
         bool? GeoJson { get; set; }
 
         /// <summary>
-        /// Supported by indexes of type <see cref="IndexTypes.TTL"/>.
         /// The time interval (in seconds) from the point in time stored in the <see cref="Fields"/> property
         /// after which the documents count as expired.
         /// Can be set to 0 to let documents expire as soon as the server time
@@ -88,7 +72,6 @@ namespace ArangoDBNetStandard.IndexApi.Models
         int? ExpireAfter { get; set; }
 
         /// <summary>
-        /// Supported by indexes of type <see cref="IndexTypes.FullText"/>.
         /// Minimum character length of words to index.
         /// </summary>
         int? MinLength { get; set; }
@@ -115,5 +98,20 @@ namespace ArangoDBNetStandard.IndexApi.Models
         /// see https://www.arangodb.com/docs/stable/http/indexes-geo.html
         /// </summary>
         int? WorstIndexedLevel { get; set; }
+
+        /// <summary>
+        /// Introduced in v3.10.
+        /// An array of additional index attribute paths in a persistent index.
+        /// These additional attributes cannot be used for index lookups or
+        /// sorts, but they can be used for projections.
+        /// </summary>
+        List<string> StoredValues { get; set; }
+
+        /// <summary>
+        /// Introduced in v3.10.
+        /// If true, an in-memory cache is enabled for 
+        /// index values for persistent indexes.
+        /// </summary>
+        bool? CacheEnabled { get; set; }
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/IndexResponseBase.cs
+++ b/arangodb-net-standard/IndexApi/Models/IndexResponseBase.cs
@@ -48,5 +48,19 @@ namespace ArangoDBNetStandard.IndexApi.Models
         /// index values for persistent indexes.
         /// </summary>
         public bool? CacheEnabled { get; set; }
+
+
+        /// <summary>
+        /// Introduced in v3.10.
+        /// A geo index with legacyPolygons set to true
+        /// will use the old, pre-3.10 rules for the parsing
+        /// GeoJSON polygons. This allows you to let old 
+        /// indexes produce the same, potentially wrong 
+        /// results as before an upgrade. A geo index with
+        /// legacyPolygons set to false will use the new, 
+        /// correct and consistent method for parsing of
+        /// GeoJSON polygons.
+        /// </summary>
+        public bool? LegacyPolygons { get ; set ; }
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/IndexResponseBase.cs
+++ b/arangodb-net-standard/IndexApi/Models/IndexResponseBase.cs
@@ -39,5 +39,14 @@ namespace ArangoDBNetStandard.IndexApi.Models
         public int? BestIndexedLevel { get; set; }
 
         public int? WorstIndexedLevel { get; set; }
+
+        public List<string> StoredValues { get; set; }
+
+        /// <summary>
+        /// Introduced in v3.10.
+        /// If true, an in-memory cache is enabled for 
+        /// index values for persistent indexes.
+        /// </summary>
+        public bool? CacheEnabled { get; set; }
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/IndexTypes.cs
+++ b/arangodb-net-standard/IndexApi/Models/IndexTypes.cs
@@ -38,6 +38,8 @@
         /// <summary>
         /// See https://www.arangodb.com/docs/stable/http/indexes-hash.html
         /// </summary>
-        public const string MultiDimensional = "zkd"; 
+        public const string MultiDimensional = "zkd";
+
+        public const string Inverted = "inverted";
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/IndexTypes.cs
+++ b/arangodb-net-standard/IndexApi/Models/IndexTypes.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// See https://www.arangodb.com/docs/stable/http/indexes-fulltext.html
         /// </summary>
-        public const string FullText = "fulltext";
+        public const string Fulltext = "fulltext";
 
         /// <summary>
         /// See https://www.arangodb.com/docs/stable/http/indexes-geo.html
@@ -24,5 +24,20 @@
         /// See https://www.arangodb.com/docs/stable/http/indexes-ttl.html
         /// </summary>
         public const string TTL = "ttl";
+
+        /// <summary>
+        /// See https://www.arangodb.com/docs/stable/http/indexes-skiplist.html
+        /// </summary>
+        public const string Skiplist = "skiplist";
+
+        /// <summary>
+        /// See https://www.arangodb.com/docs/stable/http/indexes-hash.html
+        /// </summary>
+        public const string Hash = "hash";
+
+        /// <summary>
+        /// See https://www.arangodb.com/docs/stable/http/indexes-hash.html
+        /// </summary>
+        public const string MultiDimensional = "zkd"; 
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/InvertedIndexField.cs
+++ b/arangodb-net-standard/IndexApi/Models/InvertedIndexField.cs
@@ -10,5 +10,6 @@ namespace ArangoDBNetStandard.IndexApi.Models
         public bool? SearchField { get; set; }
         public bool? TrackListPositions { get; set; }
         public IEnumerable<string> Features { get; set; }
+        public IEnumerable<InvertedIndexField> Nested { get; set; }
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/InvertedIndexField.cs
+++ b/arangodb-net-standard/IndexApi/Models/InvertedIndexField.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.IndexApi.Models
+{
+    public class InvertedIndexField
+    {
+        public string Name { get; set; }
+        public string Analyzer { get; set; }
+        public bool? IncludeAllFields { get; set; }
+        public bool? SearchField { get; set; }
+        public bool? TrackListPositions { get; set; }
+        public IEnumerable<string> Features { get; set; }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Models/InvertedIndexSort.cs
+++ b/arangodb-net-standard/IndexApi/Models/InvertedIndexSort.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.IndexApi.Models
+{
+    public class InvertedIndexSort
+    {
+        public IEnumerable<InvertedIndexSortItem> Fields { get; set; }
+        public string Compression { get; set; }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Models/InvertedIndexSortItem.cs
+++ b/arangodb-net-standard/IndexApi/Models/InvertedIndexSortItem.cs
@@ -1,0 +1,8 @@
+﻿namespace ArangoDBNetStandard.IndexApi.Models
+{
+    public class InvertedIndexSortItem
+    {
+        public string Field { get; set; }
+        public string Direction { get; set; }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Models/InvertedIndexStoredValue.cs
+++ b/arangodb-net-standard/IndexApi/Models/InvertedIndexStoredValue.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.IndexApi.Models
+{
+    public class InvertedIndexStoredValue
+    {
+        public IEnumerable<string> Fields { get; set; }
+        public string Compression { get; set; }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Models/PostFulltextIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostFulltextIndexBody.cs
@@ -1,0 +1,21 @@
+﻿namespace ArangoDBNetStandard.IndexApi.Models
+{
+    /// <summary>
+    /// Request body to create a Fulltext index
+    /// </summary>
+    public class PostFulltextIndexBody : PostIndexBody
+    {
+        public PostFulltextIndexBody()
+        {
+            Type = IndexTypes.Fulltext;
+        }
+
+        /// <summary>
+        /// Required. Minimum character length of words to
+        /// index. Will default to a server-defined value 
+        /// if unspecified. It is thus recommended to set
+        /// this value explicitly when creating the index.
+        /// </summary>
+        public long MinLength { get; set; }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Models/PostGeoSpatialIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostGeoSpatialIndexBody.cs
@@ -1,0 +1,25 @@
+﻿namespace ArangoDBNetStandard.IndexApi.Models
+{
+    /// <summary>
+    /// Request body to create a Geo-Spatial index
+    /// </summary>
+    public class PostGeoSpatialIndexBody : PostIndexBody
+    {
+        public PostGeoSpatialIndexBody()
+        {
+            Type = IndexTypes.Geo;
+        }
+
+        /// <summary>
+        /// Optional. If a geo-spatial index on a location 
+        /// is constructed and geoJson is true, then the 
+        /// order within the array is longitude followed 
+        /// by latitude. 
+        /// </summary>
+        /// <remarks>
+        /// This corresponds to the format described in
+        /// http://geojson.org/geojson-spec.html#positions
+        /// </remarks>
+        public bool? GeoJson { get; set; }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Models/PostGeoSpatialIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostGeoSpatialIndexBody.cs
@@ -21,5 +21,18 @@
         /// http://geojson.org/geojson-spec.html#positions
         /// </remarks>
         public bool? GeoJson { get; set; }
+
+        /// <summary>
+        /// Introduced in v3.10.
+        /// A geo index with legacyPolygons set to true
+        /// will use the old, pre-3.10 rules for the parsing
+        /// GeoJSON polygons. This allows you to let old 
+        /// indexes produce the same, potentially wrong 
+        /// results as before an upgrade. A geo index with
+        /// legacyPolygons set to false will use the new, 
+        /// correct and consistent method for parsing of
+        /// GeoJSON polygons.
+        /// </summary>
+        public bool? LegacyPolygons { get; set; }
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/PostHashIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostHashIndexBody.cs
@@ -1,0 +1,41 @@
+﻿namespace ArangoDBNetStandard.IndexApi.Models
+{
+    /// <summary>
+    /// Request body to create a hash index
+    /// </summary>
+    public class PostHashIndexBody : PostIndexBody
+    {
+        public PostHashIndexBody()
+        {
+            Type = IndexTypes.Hash;
+        }
+
+        /// <summary>
+        /// Set this property to true to create a unique index.
+        /// Setting it to false or omitting it will create a non-unique index.
+        /// </summary>
+        public bool? Unique { get; set; }
+
+        /// <summary>
+        /// Can be set to true to create a sparse index.
+        /// Sparse indexes do not index documents for
+        /// which any of the index attributes
+        /// is either not set or is null.
+        /// </summary>
+        public bool? Sparse { get; set; }
+
+        /// <summary>
+        /// The default value is true.
+        /// It controls whether inserting duplicate index 
+        /// values from the same document into a unique 
+        /// array index will lead to a unique constraint
+        /// error or not.
+        /// </summary>
+        public bool? Deduplicate { get; set; }
+    }
+
+
+
+
+
+}

--- a/arangodb-net-standard/IndexApi/Models/PostIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostIndexBody.cs
@@ -7,7 +7,7 @@ namespace ArangoDBNetStandard.IndexApi.Models
     /// <summary>
     /// Base class for the request body for creating an index for a collection.
     /// </summary>
-    public abstract class PostIndexBody
+    public class PostIndexBody
     {
         /// <summary>
         /// The name of the new index. If you do not specify a name, one will be auto-generated.
@@ -18,7 +18,7 @@ namespace ArangoDBNetStandard.IndexApi.Models
         /// The type of index to create. 
         /// Supported index types can be found in <see cref="IndexTypes"/>.
         /// </summary>
-        public string Type { get; protected set; }
+        public string Type { get; set; }
 
         /// <summary>
         /// The attributes to be indexed.

--- a/arangodb-net-standard/IndexApi/Models/PostIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostIndexBody.cs
@@ -5,13 +5,9 @@ using System.Text;
 namespace ArangoDBNetStandard.IndexApi.Models
 {
     /// <summary>
-    /// Represents a request body for creating an index for a collection.
+    /// Base class for the request body for creating an index for a collection.
     /// </summary>
-    /// <remarks>
-    /// Some properties are dependent on the type of index.
-    /// For more details, refer to ArangoDB's documentation for the index you want to create.
-    /// </remarks>
-    public class PostIndexBody
+    public abstract class PostIndexBody
     {
         /// <summary>
         /// The name of the new index. If you do not specify a name, one will be auto-generated.
@@ -22,69 +18,13 @@ namespace ArangoDBNetStandard.IndexApi.Models
         /// The type of index to create. 
         /// Supported index types can be found in <see cref="IndexTypes"/>.
         /// </summary>
-        public string Type { get; set; }
+        public string Type { get; protected set; }
 
         /// <summary>
         /// The attributes to be indexed.
         /// Depending on the index type, a single attribute or multiple attributes can be indexed.
         /// </summary>
-        /// <remarks>
-        /// For more details, refer to ArangoDB's documentation for the index you want to create.
-        /// </remarks>
         public IEnumerable<string> Fields { get; set; }
-
-        /// <summary>
-        /// Applies to indexes of type <see cref="IndexTypes.Persistent"/>.
-        /// Can be set to true to create a sparse index.
-        /// Sparse indexes do not index documents for which any of the index attributes
-        /// is either not set or is null.
-        /// </summary>
-        public bool? Sparse { get; set; }
-
-        /// <summary>
-        /// Set this property to true to create a unique index.
-        /// Setting it to false or omitting it will create a non-unique index.
-        /// </summary>
-        /// <remarks>
-        /// The following index types do not support uniqueness,
-        /// and using the unique attribute with these types may lead to an error:
-        /// <see cref="IndexTypes.Geo"/>, <see cref="IndexTypes.FullText"/>.
-        /// Unique indexes on non-shard keys are not supported in a cluster.
-        /// </remarks>
-        public bool? Unique { get; set; }
-
-        /// <summary>
-        /// Supported by indexes of type <see cref="IndexTypes.Persistent"/>. Defaults to true if not set.
-        /// This property controls whether index selectivity estimates are maintained for the index.
-        /// </summary>
-        public bool? Estimates { get; set; }
-
-        /// <summary>
-        /// Supported by array indexes of type <see cref="IndexTypes.Persistent"/>. The default value is true.
-        /// It controls whether inserting duplicate index values from the same document
-        /// into a unique array index will lead to a unique constraint error or not.
-        /// </summary>
-        public bool? Deduplicate { get; set; }
-
-        /// <summary>
-        /// Supported by indexes of type <see cref="IndexTypes.Geo"/>.
-        /// If a geo-spatial index on a location is constructed and geoJson is true,
-        /// then the order within the array is longitude followed by latitude.
-        /// </summary>
-        /// <remarks>
-        /// This corresponds to the format described in http://geojson.org/geojson-spec.html#positions
-        /// </remarks>
-        public bool? GeoJson { get; set; }
-
-        /// <summary>
-        /// Supported by indexes of type <see cref="IndexTypes.TTL"/>.
-        /// The time interval (in seconds) from the point in time stored in the <see cref="Fields"/> property
-        /// after which the documents count as expired.
-        /// Can be set to 0 to let documents expire as soon as the server time
-        /// passes the point in time stored in the document attribute,
-        /// or to a higher number to delay the expiration.
-        /// </summary>
-        public int? ExpireAfter { get; set; }
 
         /// <summary>
         /// Can be set to true to create the index in the background,
@@ -92,13 +32,5 @@ namespace ArangoDBNetStandard.IndexApi.Models
         /// as long as if the index is built in the foreground.
         /// </summary>
         public bool? InBackground { get; set; }
-
-        /// <summary>
-        /// Supported by indexes of type <see cref="IndexTypes.FullText"/>.
-        /// Minimum character length of words to index.
-        /// Will default to a server-defined value if unspecified.
-        /// It is thus recommended to set this value explicitly when creating the index.
-        /// </summary>
-        public int? MinLength { get; set; }
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/PostInvertedIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostInvertedIndexBody.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.IndexApi.Models
+{
+    public class PostInvertedIndexBody : PostIndexBody
+    {
+        public PostInvertedIndexBody()
+        {
+            Type = IndexTypes.Inverted;
+        }
+        public int? Parallelism { get; set; }
+        public IEnumerable<InvertedIndexStoredValue> StoredValues { get; set; }
+        public InvertedIndexSort PrimarySort { get; set; }
+        public string Analyzer { get; set; }
+        public IEnumerable<string> Features { get; set; }
+        public bool? IncludeAllFields { get; set; }
+        public bool? TrackListPositions { get; set; }
+        public bool? SearchField { get; set; }
+        public new IEnumerable<InvertedIndexField> Fields { get; set; }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Models/PostMultiDimensionalIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostMultiDimensionalIndexBody.cs
@@ -1,0 +1,20 @@
+﻿namespace ArangoDBNetStandard.IndexApi.Models
+{
+    /// <summary>
+    /// Request body to create a Multi-Dimensional index
+    /// </summary>
+    public class PostMultiDimensionalIndexBody : PostIndexBody
+    {
+        public PostMultiDimensionalIndexBody()
+        {
+            Type = IndexTypes.MultiDimensional;
+            FieldValueTypes = "double";
+        }
+
+        /// <summary>
+        /// Required. Always initialized to the value "double". 
+        /// Currently only doubles are supported as values.
+        /// </summary>
+        public string FieldValueTypes { get; private set; }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Models/PostMultiDimensionalIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostMultiDimensionalIndexBody.cs
@@ -15,6 +15,6 @@
         /// Required. Always initialized to the value "double". 
         /// Currently only doubles are supported as values.
         /// </summary>
-        public string FieldValueTypes { get; private set; }
+        public string FieldValueTypes { get; set; }
     }
 }

--- a/arangodb-net-standard/IndexApi/Models/PostPersistentIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostPersistentIndexBody.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.IndexApi.Models
+{
+    /// <summary>
+    /// Request body to create a persistent index
+    /// </summary>
+    public class PostPersistentIndexBody : PostIndexBody
+    {
+        public PostPersistentIndexBody() 
+        {
+            Type = IndexTypes.Persistent;
+        }
+
+        /// <summary>
+        /// Set this property to true to create a unique index.
+        /// Setting it to false or omitting it will create a non-unique index.
+        /// </summary>
+        public bool? Unique { get; set; }
+
+        /// <summary>
+        /// Can be set to true to create a sparse index.
+        /// Sparse indexes do not index documents for
+        /// which any of the index attributes
+        /// is either not set or is null.
+        /// </summary>
+        public bool? Sparse { get; set; }
+
+        /// <summary>
+        /// The default value is true.
+        /// It controls whether inserting duplicate index 
+        /// values from the same document into a unique 
+        /// array index will lead to a unique constraint
+        /// error or not.
+        /// </summary>
+        public bool? Deduplicate { get; set; }
+
+        /// <summary>
+        /// Defaults to true if not set.
+        /// This property controls whether index selectivity
+        /// estimates are maintained for the index.
+        /// </summary>
+        public bool? Estimates { get; set; }
+
+        /// <summary>
+        /// Introduced in v3.10.
+        /// An array of additional index attribute paths in a persistent index.
+        /// These additional attributes cannot be used for index lookups or
+        /// sorts, but they can be used for projections.
+        /// </summary>
+        /// <remarks>
+        /// There must be no overlap of attribute paths between 
+        /// <see cref="PostIndexBody.Fields"/> and <see cref="StoredValues"/>. 
+        /// The maximum number of values is 32.
+        /// </remarks>
+        public IEnumerable<string> StoredValues { get; set; }
+
+        /// <summary>
+        /// Introduced in v3.10
+        /// Can be set to true to enable an in-memory cache for 
+        /// index values for persistent indexes. Otherwise the
+        /// index is created without it. Caching is turned off
+        /// by default.
+        /// </summary>
+        public bool? CacheEnabled { get; set; }
+    }
+
+
+
+
+
+}

--- a/arangodb-net-standard/IndexApi/Models/PostSkiplistIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostSkiplistIndexBody.cs
@@ -1,0 +1,41 @@
+﻿namespace ArangoDBNetStandard.IndexApi.Models
+{
+    /// <summary>
+    /// Request body to create a skiplist index
+    /// </summary>
+    public class PostSkiplistIndexBody : PostIndexBody
+    {
+        public PostSkiplistIndexBody()
+        {
+            Type = IndexTypes.Skiplist;
+        }
+
+        /// <summary>
+        /// Set this property to true to create a unique index.
+        /// Setting it to false or omitting it will create a non-unique index.
+        /// </summary>
+        public bool? Unique { get; set; }
+
+        /// <summary>
+        /// Can be set to true to create a sparse index.
+        /// Sparse indexes do not index documents for
+        /// which any of the index attributes
+        /// is either not set or is null.
+        /// </summary>
+        public bool? Sparse { get; set; }
+
+        /// <summary>
+        /// The default value is true.
+        /// It controls whether inserting duplicate index 
+        /// values from the same document into a unique 
+        /// array index will lead to a unique constraint
+        /// error or not.
+        /// </summary>
+        public bool? Deduplicate { get; set; }
+    }
+
+
+
+
+
+}

--- a/arangodb-net-standard/IndexApi/Models/PostSkiplistIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostSkiplistIndexBody.cs
@@ -33,9 +33,4 @@
         /// </summary>
         public bool? Deduplicate { get; set; }
     }
-
-
-
-
-
 }

--- a/arangodb-net-standard/IndexApi/Models/PostTTLIndexBody.cs
+++ b/arangodb-net-standard/IndexApi/Models/PostTTLIndexBody.cs
@@ -1,0 +1,24 @@
+﻿namespace ArangoDBNetStandard.IndexApi.Models
+{
+    /// <summary>
+    /// Request body to create a TTL (time-to-live) index
+    /// </summary>
+    public class PostTTLIndexBody : PostIndexBody
+    {
+        public PostTTLIndexBody()
+        {
+            Type = IndexTypes.TTL;
+        }
+
+        /// <summary>
+        /// Required. The time interval (in seconds) from the point 
+        /// in time stored in the fields attribute after
+        /// which the documents count as expired. Can be 
+        /// set to 0 to let documents expire as soon as 
+        /// the server time passes the point in time stored
+        /// in the document attribute, or to a higher 
+        /// number to delay the expiration.
+        /// </summary>
+        public int ExpireAfter { get; set; }
+    }
+}


### PR DESCRIPTION
1) Use separate async methods to POST different index types. This way when one type of deprecated, we can simply deprecate the method. Fulltext is deprecated in 3.10.
2) Index cache: added CacheEnabled property for persistent indexes. Introduced in 3.10.
3) Index stored values: added StoredValues property for persistent indexes. Introduced in 3.10.
4) Deprecate fulltext index in 3.10.
5) Geo index legacyPolygons: added legacyPolygons property. Introduced in 3.10.
6) Added InvertedIndex support for ArangoSearch. 

Note that documentation has not been finalized. Once it is, we will update code documentation on the several classes and properties involved.

ArangoDB 3.10 Index API changes: https://github.com/arangodb/docs/blob/main/3.10/release-notes-api-changes310.md#index-api