### PR TITLE
Revert "Bump Newtonsoft.Json from 12.0.2 to 13.0.1 in /arangodb-net-standard"

### DIFF
--- a/arangodb-net-standard/ArangoDBNetStandard.csproj
+++ b/arangodb-net-standard/ArangoDBNetStandard.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts ArangoDB-Community/arangodb-net-standard#384

This is a breaking change that we agreed to revert temporarily.