### PR TITLE
Revert "Renamed CursorResponse to PostCursorResponse"

### DIFF
--- a/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
+++ b/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
@@ -319,7 +319,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         [Fact]
         public async Task PutCursorAsync_ShouldReturnResponseModelWithInterface()
         {
-            PostCursorResponse<int> postResponse =
+            CursorResponse<int> postResponse =
                 await _cursorApi.PostCursorAsync<int>("FOR i IN 0..1500 RETURN i");
 
             ICursorResponse<int> putResult =

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -71,7 +71,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="transactionId">Optional. The stream transaction Id.</param>      
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
+        public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(
                 string query,
                 Dictionary<string, object> bindVars = null,
                 PostCursorOptions options = null,
@@ -116,7 +116,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
+        public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(
             PostCursorBody postCursorBody, 
             CursorHeaderProperties headerProperties = null,
             CancellationToken token = default)
@@ -131,7 +131,7 @@ namespace ArangoDBNetStandard.CursorApi
                 if (response.IsSuccessStatusCode)
                 {
                     var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                    return DeserializeJsonFromStream<PostCursorResponse<T>>(stream);
+                    return DeserializeJsonFromStream<CursorResponse<T>>(stream);
                 }
 
                 throw await GetApiErrorException(response).ConfigureAwait(false);

--- a/arangodb-net-standard/CursorApi/ICursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/ICursorApiClient.cs
@@ -25,7 +25,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="transactionId">Optional. The stream transaction Id.</param>      
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<PostCursorResponse<T>> PostCursorAsync<T>(
+        Task<CursorResponse<T>> PostCursorAsync<T>(
                 string query,
                 Dictionary<string, object> bindVars = null,
                 PostCursorOptions options = null,
@@ -48,7 +48,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<PostCursorResponse<T>> PostCursorAsync<T>(
+        Task<CursorResponse<T>> PostCursorAsync<T>(
             PostCursorBody postCursorBody, 
             CursorHeaderProperties headerProperties = null,
             CancellationToken token = default);

--- a/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
+++ b/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
@@ -7,7 +7,7 @@ namespace ArangoDBNetStandard.CursorApi.Models
     /// Response from ArangoDB when creating a new cursor.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class PostCursorResponse<T> : ICursorResponse<T>
+    public class CursorResponse<T> : ICursorResponse<T>
     {
         /// <summary>
         /// Indicates whether an error occurred


### PR DESCRIPTION
This reverts commit [ddecb1c7e038b8b9bf8f65ae4b59363f711eb15e](https://github.com/ArangoDB-Community/arangodb-net-standard/pull/387/commits/ddecb1c7e038b8b9bf8f65ae4b59363f711eb15e).

This is a breaking change that we agreed to revert temporarily.