### PR TITLE
Fix compilation warnings caused by XML doc comments.

### DIFF
--- a/arangodb-net-standard/AdminApi/Models/GetLogsQuery.cs
+++ b/arangodb-net-standard/AdminApi/Models/GetLogsQuery.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.AdminApi.Models
 {
     /// <summary>
-    /// Parameters for <see cref="IAdminApiClient.GetLogsAsync(GetLogsQuery)"/>
+    /// Parameters for <see cref="IAdminApiClient.GetLogsAsync"/>
     /// </summary>
     public class GetLogsQuery
     {

--- a/arangodb-net-standard/AdminApi/Models/GetLogsResponse.cs
+++ b/arangodb-net-standard/AdminApi/Models/GetLogsResponse.cs
@@ -4,7 +4,7 @@ using System.Text;
 namespace ArangoDBNetStandard.AdminApi.Models
 {
     /// <summary>
-    /// Returned by <see cref="IAdminApiClient.GetLogsAsync(GetLogsQuery)"/>
+    /// Returned by <see cref="IAdminApiClient.GetLogsAsync"/>
     /// </summary>
     public class GetLogsResponse
     {

--- a/arangodb-net-standard/AdminApi/Models/GetServerVersionQuery.cs
+++ b/arangodb-net-standard/AdminApi/Models/GetServerVersionQuery.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.AdminApi.Models
 {
     /// <summary>
-    /// Parameters for <see cref="IAdminApiClient.GetServerVersionAsync(GetServerVersionQuery)"/>
+    /// Parameters for <see cref="IAdminApiClient.GetServerVersionAsync"/>
     /// </summary>
     public class GetServerVersionQuery
     {

--- a/arangodb-net-standard/AdminApi/Models/GetServerVersionResponse.cs
+++ b/arangodb-net-standard/AdminApi/Models/GetServerVersionResponse.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.AdminApi.Models
 {
     /// <summary>
-    /// Returned by <see cref="IAdminApiClient.GetServerVersionAsync(GetServerVersionQuery)"/>
+    /// Returned by <see cref="IAdminApiClient.GetServerVersionAsync"/>
     /// </summary>
     public class GetServerVersionResponse
     {

--- a/arangodb-net-standard/AnalyzerApi/Models/DeleteAnalyzerResponse.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/DeleteAnalyzerResponse.cs
@@ -1,7 +1,7 @@
 ﻿namespace ArangoDBNetStandard.AnalyzerApi.Models
 {
     /// <summary>
-    /// Response from <see cref="IAnalyzerApiClient.DeleteAnalyzerAsync(string)"/>
+    /// Response from <see cref="IAnalyzerApiClient.DeleteAnalyzerAsync"/>
     /// </summary>
     public class DeleteAnalyzerResponse : ResponseBase
     {

--- a/arangodb-net-standard/AnalyzerApi/Models/GetAnalyzerResponse.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/GetAnalyzerResponse.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.AnalyzerApi.Models
 {
     /// <summary>
-    /// Response from <see cref="IAnalyzerApiClient.GetAnalyzerAsync(string)"/>
+    /// Response from <see cref="IAnalyzerApiClient.GetAnalyzerAsync"/>
     /// </summary>
     public class GetAnalyzerResponse : Analyzer
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/CachedAqlQueryResult.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/CachedAqlQueryResult.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace ArangoDBNetStandard.AqlFunctionApi.Models
 {
     /// <summary>
-    /// Response from <see cref="AqlFunctionApiClient.GetCachedAqlQueryResultsAsync()"/>
+    /// Response from <see cref="AqlFunctionApiClient.GetCachedAqlQueryResultsAsync"/>
     /// Represents a cached AQL query result.
     /// </summary>
     public class CachedAqlQueryResult

--- a/arangodb-net-standard/AqlFunctionApi/Models/DeleteClearSlowAqlQueriesQuery.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/DeleteClearSlowAqlQueriesQuery.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Generates query string for 
-    /// <see cref="AqlFunctionApiClient.DeleteClearSlowAqlQueriesAsync(DeleteClearSlowAqlQueriesQuery)"/>
+    /// <see cref="AqlFunctionApiClient.DeleteClearSlowAqlQueriesAsync"/>
     /// </summary>
     public class DeleteClearSlowAqlQueriesQuery
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/DeleteKillRunningAqlQueryQuery.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/DeleteKillRunningAqlQueryQuery.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Generates query string for 
-    /// <see cref="AqlFunctionApiClient.DeleteKillRunningAqlQueryAsync(string, DeleteKillRunningAqlQueryQuery)"/>
+    /// <see cref="AqlFunctionApiClient.DeleteKillRunningAqlQueryAsync"/>
     /// </summary>
     public class DeleteKillRunningAqlQueryQuery
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/GetCurrentlyRunningAqlQueriesQuery.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/GetCurrentlyRunningAqlQueriesQuery.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Generates query string for 
-    /// <see cref="AqlFunctionApiClient.GetCurrentlyRunningAqlQueriesAsync(GetCurrentlyRunningAqlQueriesQuery)"/>
+    /// <see cref="AqlFunctionApiClient.GetCurrentlyRunningAqlQueriesAsync"/>
     /// </summary>
     public class GetCurrentlyRunningAqlQueriesQuery
     {
@@ -26,5 +26,5 @@
                 return "";
             }
         }
-    }   
+    }
 }

--- a/arangodb-net-standard/AqlFunctionApi/Models/GetSlowAqlQueriesQuery.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/GetSlowAqlQueriesQuery.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Generates query string for 
-    /// <see cref="AqlFunctionApiClient.GetSlowAqlQueriesAsync(GetSlowAqlQueriesQuery)"/>
+    /// <see cref="AqlFunctionApiClient.GetSlowAqlQueriesAsync"/>
     /// </summary>
     public class GetSlowAqlQueriesQuery
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryBody.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryBody.cs
@@ -4,7 +4,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
 {
     /// <summary>
     /// Request body for 
-    /// <see cref="AqlFunctionApiClient.PostExplainAqlQueryAsync(PostExplainAqlQueryBody)"/>
+    /// <see cref="AqlFunctionApiClient.PostExplainAqlQueryAsync"/>
     /// </summary>
     public class PostExplainAqlQueryBody
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponse.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponse.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.AqlFunctionApi.Models
 {
     /// <summary>
-    /// Response from <see cref="AqlFunctionApiClient.PostExplainAqlQueryAsync(PostExplainAqlQueryBody)"/>
+    /// Response from <see cref="AqlFunctionApiClient.PostExplainAqlQueryAsync"/>
     /// See https://www.arangodb.com/docs/stable/http/aql-query.html#explain-an-aql-query
     /// </summary>
     public class PostExplainAqlQueryResponse:ResponseBase

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostParseAqlQueryBody.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostParseAqlQueryBody.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Request body for 
-    /// <see cref="AqlFunctionApiClient.PostParseAqlQueryAsync(PostParseAqlQueryBody) "/>
+    /// <see cref="AqlFunctionApiClient.PostParseAqlQueryAsync"/>
     /// </summary>
     public class PostParseAqlQueryBody
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostParseAqlQueryResponse.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostParseAqlQueryResponse.cs
@@ -4,7 +4,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
 {
     /// <summary>
     /// Response from
-    /// <see cref="AqlFunctionApiClient.PostParseAqlQueryAsync(PostParseAqlQueryBody)"/>
+    /// <see cref="AqlFunctionApiClient.PostParseAqlQueryAsync"/>
     /// </summary>
     public class PostParseAqlQueryResponse : ResponseBase
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/PutAdjustQueryCacheGlobalPropertiesBody.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PutAdjustQueryCacheGlobalPropertiesBody.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Parameter to
-    /// <see cref="AqlFunctionApiClient.PutAdjustQueryCacheGlobalPropertiesAsync(PutAdjustQueryCacheGlobalPropertiesBody)"/>
+    /// <see cref="AqlFunctionApiClient.PutAdjustQueryCacheGlobalPropertiesAsync"/>
     /// </summary>
     public class PutAdjustQueryCacheGlobalPropertiesBody
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/PutChangeQueryTrackingConfigurationBody.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PutChangeQueryTrackingConfigurationBody.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Parameter to
-    /// <see cref="AqlFunctionApiClient.PutChangeQueryTrackingConfigurationAsync(PutChangeQueryTrackingConfigurationBody)"/>
+    /// <see cref="AqlFunctionApiClient.PutChangeQueryTrackingConfigurationAsync"/>
     /// </summary>
     public class PutChangeQueryTrackingConfigurationBody
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/QueryCacheGlobalProperties.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/QueryCacheGlobalProperties.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents the global properties of the AQL Query Cache
     /// Response from
-    /// <see cref="AqlFunctionApiClient.GetQueryCacheGlobalPropertiesAsync()"/>
+    /// <see cref="AqlFunctionApiClient.GetQueryCacheGlobalPropertiesAsync"/>
     /// </summary>
     public class QueryCacheGlobalProperties
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/QueryTrackingConfiguration.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/QueryTrackingConfiguration.cs
@@ -3,9 +3,9 @@
     /// <summary>
     /// Represents the global properties of the AQL Query Cache
     /// Returned by
-    /// <see cref="AqlFunctionApiClient.GetQueryTrackingConfigurationAsync()"/>
+    /// <see cref="AqlFunctionApiClient.GetQueryTrackingConfigurationAsync"/>
     /// and 
-    /// <see cref="AqlFunctionApiClient.PutChangeQueryTrackingConfigurationAsync(PutChangeQueryTrackingConfigurationBody)"/>
+    /// <see cref="AqlFunctionApiClient.PutChangeQueryTrackingConfigurationAsync"/>
     /// </summary>
     public class QueryTrackingConfiguration : ResponseBase
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/RunningAqlQuery.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/RunningAqlQuery.cs
@@ -5,7 +5,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
 {
     /// <summary>
     /// Response from
-    /// <see cref="AqlFunctionApiClient.GetCurrentlyRunningAqlQueriesAsync(GetCurrentlyRunningAqlQueriesQuery)"/>
+    /// <see cref="AqlFunctionApiClient.GetCurrentlyRunningAqlQueriesAsync"/>
     /// </summary>
     public class RunningAqlQuery
     {

--- a/arangodb-net-standard/AqlFunctionApi/Models/SlowAqlQuery.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/SlowAqlQuery.cs
@@ -4,7 +4,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
 {
     /// <summary>
     /// Response from
-    /// <see cref="AqlFunctionApiClient.GetSlowAqlQueriesAsync(GetSlowAqlQueriesQuery)"/>
+    /// <see cref="AqlFunctionApiClient.GetSlowAqlQueriesAsync"/>
     /// Represents an AQL query that are finished 
     /// and have exceeded the slow query threshold 
     /// in the selected database.

--- a/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsQuery.cs
+++ b/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsQuery.cs
@@ -19,7 +19,7 @@ namespace ArangoDBNetStandard.BulkOperationsApi.Models
         public string Collection { get; set; }
 
         /// <summary>
-        /// Required for <see cref="BulkOperationsApiClient.PostImportDocumentObjectsAsync(ImportDocumentsQuery, ImportDocumentObjectsBody)"/>
+        /// Required for <see cref="BulkOperationsApiClient.PostImportDocumentObjectsAsync"/>
         /// Determines how the body of the request will be interpreted.
         /// Type can have the following values:
         /// 1) documents: When this type is used, each line in 

--- a/arangodb-net-standard/CollectionApi/Models/ComputedValue.cs
+++ b/arangodb-net-standard/CollectionApi/Models/ComputedValue.cs
@@ -22,7 +22,7 @@ namespace ArangoDBNetStandard.CollectionApi.Models
         /// <summary>
         /// Required. An AQL RETURN operation with an
         /// expression that computes the desired value. 
-        /// <see cref="https://www.arangodb.com/docs/stable/data-modeling-documents-computed-values.html#computed-value-expressions"/>
+        /// https://www.arangodb.com/docs/stable/data-modeling-documents-computed-values.html#computed-value-expressions
         /// </summary>
         public string Expression { get; set; }
 

--- a/arangodb-net-standard/CollectionApi/Models/GetChecksumQuery.cs
+++ b/arangodb-net-standard/CollectionApi/Models/GetChecksumQuery.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace ArangoDBNetStandard.CollectionApi.Models
 {
     /// <summary>
-    /// Generates query for <see cref="ICollectionApiClient.GetChecksumAsync(string, GetChecksumQuery)"/>
+    /// Generates query for <see cref="ICollectionApiClient.GetChecksumAsync"/>
     /// </summary>
     public class GetChecksumQuery
     {

--- a/arangodb-net-standard/CollectionApi/Models/GetChecksumResponse.cs
+++ b/arangodb-net-standard/CollectionApi/Models/GetChecksumResponse.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace ArangoDBNetStandard.CollectionApi.Models
 {
     /// <summary>
-    /// Response from <see cref="ICollectionApiClient.GetChecksumAsync(string, GetChecksumQuery)"/>
+    /// Response from <see cref="ICollectionApiClient.GetChecksumAsync"/>
     /// </summary>
     public class GetChecksumResponse:ResponseBase
     {

--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -423,7 +423,6 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName">The name of the edge collection the edge belongs to.</param>
         /// <param name="edgeKey">The _key attribute of the edge.</param>
         /// <param name="query"></param>
-        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <param name="headers">Headers to use for this operation.</param>        
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>

--- a/arangodb-net-standard/GraphApi/IGraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/IGraphApiClient.cs
@@ -54,6 +54,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// GET /_api/gharial/{graph}
         /// </summary>
         /// <param name="graphName"></param>
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetGraphResponse> GetGraphAsync(string graphName, CancellationToken token = default);
 

--- a/arangodb-net-standard/IndexApi/Models/GetAllCollectionIndexesResponse.cs
+++ b/arangodb-net-standard/IndexApi/Models/GetAllCollectionIndexesResponse.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace ArangoDBNetStandard.IndexApi.Models
 {
     /// <summary>
-    /// Response from <see cref="IndexApiClient.GetAllCollectionIndexesAsync(GetAllCollectionIndexesQuery)"/>
+    /// Response from <see cref="IndexApiClient.GetAllCollectionIndexesAsync"/>
     /// </summary>
     public class GetAllCollectionIndexesResponse : ResponseBase
     {

--- a/arangodb-net-standard/IndexApi/Models/GetIndexResponse.cs
+++ b/arangodb-net-standard/IndexApi/Models/GetIndexResponse.cs
@@ -1,7 +1,7 @@
 ﻿namespace ArangoDBNetStandard.IndexApi.Models
 {
     /// <summary>
-    /// Response from <see cref="IndexApiClient.GetIndexAsync(string)"/>
+    /// Response from <see cref="IndexApiClient.GetIndexAsync"/>
     /// </summary>
     public class GetIndexResponse : IndexResponseBase
     {

--- a/arangodb-net-standard/PregelApi/IPregelApiClient.cs
+++ b/arangodb-net-standard/PregelApi/IPregelApiClient.cs
@@ -64,7 +64,7 @@ namespace ArangoDBNetStandard.PregelApi
         /// discard any intermediate results. This will immediately 
         /// free all memory taken up by the execution, and will 
         /// make you lose all intermediary data.
-        /// For more information <see cref="https://www.arangodb.com/docs/stable/http/pregel.html#cancel-pregel-job-execution"/>
+        /// For more information see https://www.arangodb.com/docs/stable/http/pregel.html#cancel-pregel-job-execution
         /// </remarks>
         /// <param name="jobId">The ID of the job.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>

--- a/arangodb-net-standard/PregelApi/Models/PostStartJobBody.cs
+++ b/arangodb-net-standard/PregelApi/Models/PostStartJobBody.cs
@@ -50,7 +50,7 @@ namespace ArangoDBNetStandard.PregelApi.Models
         /// General as well as algorithm-specific options.
         /// </summary>
         /// <remarks>
-        /// <see cref="https://www.arangodb.com/docs/stable/http/pregel.html#start-pregel-job-execution"/>
+        /// https://www.arangodb.com/docs/stable/http/pregel.html#start-pregel-job-execution
         /// </remarks>
         public Dictionary<string,object> Params { get; set; }
     }

--- a/arangodb-net-standard/PregelApi/PregelApiClient.cs
+++ b/arangodb-net-standard/PregelApi/PregelApiClient.cs
@@ -137,7 +137,7 @@ namespace ArangoDBNetStandard.PregelApi
         /// discard any intermediate results. This will immediately 
         /// free all memory taken up by the execution, and will 
         /// make you lose all intermediary data.
-        /// For more information <see cref="https://www.arangodb.com/docs/stable/http/pregel.html#cancel-pregel-job-execution"/>
+        /// For more information see https://www.arangodb.com/docs/stable/http/pregel.html#cancel-pregel-job-execution
         /// </remarks>
         /// <param name="jobId">The ID of the job.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>

--- a/arangodb-net-standard/ViewApi/Models/DeleteViewResponse.cs
+++ b/arangodb-net-standard/ViewApi/Models/DeleteViewResponse.cs
@@ -1,7 +1,7 @@
 ﻿namespace ArangoDBNetStandard.ViewApi.Models
 {
     /// <summary>
-    /// Response from <see cref="IViewApiClient.DeleteViewAsync(string)"/>
+    /// Response from <see cref="IViewApiClient.DeleteViewAsync"/>
     /// </summary>
     public class DeleteViewResponse :ResponseBase
     {

--- a/arangodb-net-standard/ViewApi/Models/GetViewPropertiesResponse.cs
+++ b/arangodb-net-standard/ViewApi/Models/GetViewPropertiesResponse.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.ViewApi.Models
 {
     /// <summary>
-    /// Response from <see cref="IViewApiClient.GetViewPropertiesAsync(string)"/>
+    /// Response from <see cref="IViewApiClient.GetViewPropertiesAsync"/>
     /// </summary>
     public class GetViewPropertiesResponse : ViewResponse
     {

--- a/arangodb-net-standard/ViewApi/Models/GetViewResponse.cs
+++ b/arangodb-net-standard/ViewApi/Models/GetViewResponse.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.ViewApi.Models
 {
     /// <summary>
-    /// Response from <see cref="IViewApiClient.GetViewAsync(string)"/>
+    /// Response from <see cref="IViewApiClient.GetViewAsync"/>
     /// </summary>
     public class GetViewResponse : ViewSummary
     {

--- a/arangodb-net-standard/ViewApi/Models/PutRenameViewBody.cs
+++ b/arangodb-net-standard/ViewApi/Models/PutRenameViewBody.cs
@@ -1,7 +1,7 @@
 ﻿namespace ArangoDBNetStandard.ViewApi.Models
 {
     /// <summary>
-    /// Body parameters for <see cref="IViewApiClient.PutRenameViewAsync(string, PutRenameViewBody)"/>
+    /// Body parameters for <see cref="IViewApiClient.PutRenameViewAsync"/>
     /// </summary>
     public class PutRenameViewBody
     {

--- a/arangodb-net-standard/ViewApi/Models/PutRenameViewResponse.cs
+++ b/arangodb-net-standard/ViewApi/Models/PutRenameViewResponse.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.ViewApi.Models
 {
     /// <summary>
-    /// Response from <see cref="IViewApiClient.PutRenameViewAsync(string, PutRenameViewBody)"/>
+    /// Response from <see cref="IViewApiClient.PutRenameViewAsync"/>
     /// </summary>
     public class PutRenameViewResponse : ViewSummary
     {


### PR DESCRIPTION
Some XML doc tags `<see />` had web links in them, which causes warnings. Web links should just be pasted as is.

Some tags also used to reference a specific method signature but the signature has changed since. I've updated the reference to only use the method name.