### PR TITLE
Renamed PostCursorResponse to CursorResponse

### DIFF
--- a/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
+++ b/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
@@ -44,7 +44,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         [Fact]
         public async Task PostCursorAsync_ShouldSucceed_WhenQueryResultsInWarnings()
         {
-            var response = await _cursorApi.PostCursorAsync<object>("RETURN 1 / 0",null);
+            var response = await _cursorApi.PostCursorAsync<object>("RETURN 1 / 0");
 
             Assert.Single(response.Result);
             Assert.Null(response.Result.First());
@@ -158,7 +158,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
             {
-                await _cursorApi.PostCursorAsync<MyModel>("RETURN blah", null);
+                await _cursorApi.PostCursorAsync<MyModel>("RETURN blah");
             });
 
             Assert.NotNull(ex.ApiError.ErrorMessage);
@@ -197,7 +197,7 @@ namespace ArangoDBNetStandardTest.CursorApi
 
             var ex = await Assert.ThrowsAsync<SerializationException>(async () =>
             {
-                await cursorApi.PostCursorAsync<object>("RETURN true", null);
+                await cursorApi.PostCursorAsync<object>("RETURN true");
             });
 
             Assert.NotNull(ex.Message);
@@ -210,7 +210,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         {
             var ex = await Assert.ThrowsAsync<SerializationException>(async () =>
             {
-                await _cursorApi.PostCursorAsync<int>("RETURN null", null);
+                await _cursorApi.PostCursorAsync<int>("RETURN null");
             });
 
             Assert.NotNull(ex.Message);
@@ -274,7 +274,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         public async Task PostCursorAsync_ShouldReturnResponseModelWithInterface()
         {
             ICursorResponse<MyModel> response =
-                await _cursorApi.PostCursorAsync<MyModel>("RETURN {}", null);
+                await _cursorApi.PostCursorAsync<MyModel>("RETURN {}");
 
             Assert.NotNull(response);
         }
@@ -283,7 +283,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         [Trait("ServerVersion", "3_8_PLUS")]
         public async Task PostAdvanceCursorAsync_ShouldSucceed()
         {
-            var response = await _cursorApi.PostCursorAsync<long>("FOR i IN 0..1000 RETURN i", null);
+            var response = await _cursorApi.PostCursorAsync<long>("FOR i IN 0..1000 RETURN i");
             Assert.True(response.HasMore);
 
             var nextResponse = await _cursorApi.PostAdvanceCursorAsync<long>(response.Id);
@@ -297,7 +297,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         [Trait("ServerVersion", "3_8_PLUS")]
         public async Task PostAdvanceCursorAsync_ShouldThrow_WhenCursorIsExhausted()
         {
-            var response = await _cursorApi.PostCursorAsync<long>("FOR i IN 0..1000 RETURN i", null);
+            var response = await _cursorApi.PostCursorAsync<long>("FOR i IN 0..1000 RETURN i");
             Assert.True(response.HasMore);
 
             var nextResponse = await _cursorApi.PostAdvanceCursorAsync<long>(response.Id);
@@ -324,7 +324,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         public async Task PostAdvanceCursorAsync_ShouldReturnResponseModelWithInterface()
         {
             PostCursorResponse<int> postResponse =
-                await _cursorApi.PostCursorAsync<int>("FOR i IN 0..1500 RETURN i", null);
+                await _cursorApi.PostCursorAsync<int>("FOR i IN 0..1500 RETURN i");
 
             ICursorResponse<int> putResult =
                 await _cursorApi.PostAdvanceCursorAsync<int>(postResponse.Id);
@@ -346,7 +346,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         [Fact]
         public async Task DeleteCursorAsync_ShouldSucceed()
         {
-            var response = await _cursorApi.PostCursorAsync<long>("FOR i IN 0..1000 RETURN i", null);
+            var response = await _cursorApi.PostCursorAsync<long>("FOR i IN 0..1000 RETURN i");
             Assert.True(response.HasMore);
 
             var deleteResponse = await _cursorApi.DeleteCursorAsync(response.Id);

--- a/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
+++ b/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
@@ -323,7 +323,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         [Trait("ServerVersion", "3_8_PLUS")]
         public async Task PostAdvanceCursorAsync_ShouldReturnResponseModelWithInterface()
         {
-            PostCursorResponse<int> postResponse =
+            CursorResponse<int> postResponse =
                 await _cursorApi.PostCursorAsync<int>("FOR i IN 0..1500 RETURN i");
 
             ICursorResponse<int> putResult =

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -81,7 +81,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="transactionId">Optional. The stream transaction Id.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
+        public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(
                 string query,
                 Dictionary<string, object> bindVars = null,
                 PostCursorOptions options = null,
@@ -122,7 +122,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<PostCursorResponse<T>> PostCursorAsync<T>(
+        public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(
             PostCursorBody postCursorBody, CursorHeaderProperties headerProperties = null,
             CancellationToken token = default)
         {
@@ -136,7 +136,7 @@ namespace ArangoDBNetStandard.CursorApi
                 if (response.IsSuccessStatusCode)
                 {
                     var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                    return DeserializeJsonFromStream<PostCursorResponse<T>>(stream);
+                    return DeserializeJsonFromStream<CursorResponse<T>>(stream);
                 }
 
                 throw await GetApiErrorException(response).ConfigureAwait(false);
@@ -199,7 +199,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="cursorIdentifier">The name / identifier of the existing cursor.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<PostCursorResponse<T>> PostAdvanceCursorAsync<T>(string cursorIdentifier, CancellationToken token = default)
+        public virtual async Task<CursorResponse<T>> PostAdvanceCursorAsync<T>(string cursorIdentifier, CancellationToken token = default)
         {
             using (var response = await _client.PostAsync(
                 requestUri: _cursorApiPath + $"/{WebUtility.UrlEncode(cursorIdentifier)}",
@@ -209,7 +209,7 @@ namespace ArangoDBNetStandard.CursorApi
                 if (response.IsSuccessStatusCode)
                 {
                     var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                    return DeserializeJsonFromStream<PostCursorResponse<T>>(stream);
+                    return DeserializeJsonFromStream<CursorResponse<T>>(stream);
                 }
                 throw await GetApiErrorException(response).ConfigureAwait(false);
             }

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -123,7 +123,8 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(
-            PostCursorBody postCursorBody, CursorHeaderProperties headerProperties = null,
+            PostCursorBody postCursorBody, 
+            CursorHeaderProperties headerProperties = null,
             CancellationToken token = default)
         {
             var content = GetContent(postCursorBody, new ApiClientSerializationOptions(true, true));

--- a/arangodb-net-standard/CursorApi/ICursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/ICursorApiClient.cs
@@ -25,7 +25,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="transactionId">Optional. The stream transaction Id.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<PostCursorResponse<T>> PostCursorAsync<T>(
+        Task<CursorResponse<T>> PostCursorAsync<T>(
                 string query,
                 Dictionary<string, object> bindVars = null,
                 PostCursorOptions options = null,
@@ -44,7 +44,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="headerProperties">Optional. Additional Header properties.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<PostCursorResponse<T>> PostCursorAsync<T>(
+        Task<CursorResponse<T>> PostCursorAsync<T>(
             PostCursorBody postCursorBody, 
             CursorHeaderProperties headerProperties = null,
             CancellationToken token = default);
@@ -56,7 +56,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="cursorIdentifier">The name / identifier of the existing cursor.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<PostCursorResponse<T>> PostAdvanceCursorAsync<T>(
+        Task<CursorResponse<T>> PostAdvanceCursorAsync<T>(
             string cursorIdentifier,
             CancellationToken token = default);
 

--- a/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
+++ b/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
@@ -62,5 +62,4 @@ namespace ArangoDBNetStandard.CursorApi.Models
         /// </summary>
         public string Id { get; set; }
     }
-
 }

--- a/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
+++ b/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
@@ -62,5 +62,4 @@ namespace ArangoDBNetStandard.CursorApi.Models
         /// </summary>
         public string Id { get; set; }
     }
-
-}}
+}

--- a/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
+++ b/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
@@ -62,4 +62,5 @@ namespace ArangoDBNetStandard.CursorApi.Models
         /// </summary>
         public string Id { get; set; }
     }
+
 }

--- a/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
+++ b/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
@@ -7,7 +7,7 @@ namespace ArangoDBNetStandard.CursorApi.Models
     /// Response from ArangoDB when creating a new cursor.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class PostCursorResponse<T> : ICursorResponse<T>
+    public class CursorResponse<T> : ICursorResponse<T>
     {
         /// <summary>
         /// Indicates whether an error occurred


### PR DESCRIPTION
Rename was necessary to fix issues caused by PR#396