### PR TITLE
Changed Links property type to generic object

### DIFF
--- a/arangodb-net-standard/ViewApi/Models/ViewDetails.cs
+++ b/arangodb-net-standard/ViewApi/Models/ViewDetails.cs
@@ -107,11 +107,10 @@ namespace ArangoDBNetStandard.ViewApi.Models
         public int? WritebufferSizeMax { get; set; }
 
         /// <summary>
-        /// Expects an object with the attribute keys 
-        /// being names of to be linked collections, 
-        /// and the link properties as attribute values.
+        /// An object list of linked collections, 
+        /// and the link properties.
         /// </summary>
-        public IDictionary<string, LinkProperties> Links { get; set; }
+        public object Links { get; set; }
 
         /// <summary>
         /// Introduced in 3.10. List of indexes for


### PR DESCRIPTION
There is a difference in the JSON returned for `ViewDetails.Links` between the version `3.9.5` (still being supported) and `3.10`. Therefore, to make the driver compatible with both versions, we changed the type to object. 