### PR TITLE
Dispose fix

### DIFF
--- a/arangodb-net-standard/ArangoDBClient.cs
+++ b/arangodb-net-standard/ArangoDBClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using ArangoDBNetStandard.AdminApi;
 using ArangoDBNetStandard.AnalyzerApi;
 using ArangoDBNetStandard.AqlFunctionApi;
@@ -23,7 +24,7 @@ namespace ArangoDBNetStandard
     /// <summary>
     /// Wrapper class providing access to the complete set of ArangoDB REST resources.
     /// </summary>
-    public class ArangoDBClient : IArangoDBClient
+    public class ArangoDBClient : IArangoDBClient, IDisposable
     {
         /// <summary>
         /// The transport client used to communicate with the ArangoDB host.

--- a/arangodb-net-standard/IArangoDBClient.cs
+++ b/arangodb-net-standard/IArangoDBClient.cs
@@ -17,7 +17,7 @@ using ArangoDBNetStandard.ViewApi;
 
 namespace ArangoDBNetStandard
 {
-    public interface IArangoDBClient : IDisposable
+    public interface IArangoDBClient
     {
         /// <summary>
         /// AQL user functions management API.

--- a/arangodb-net-standard/Transport/Http/HttpApiClientResponse.cs
+++ b/arangodb-net-standard/Transport/Http/HttpApiClientResponse.cs
@@ -4,11 +4,11 @@ using System.Net.Http.Headers;
 
 namespace ArangoDBNetStandard.Transport.Http
 {
-    public class HttpApiClientResponse : IApiClientResponse
+    internal class HttpApiClientResponse : IApiClientResponse
     {
         private readonly HttpResponseMessage response;
 
-        public HttpApiClientResponse(HttpResponseMessage response)
+        internal HttpApiClientResponse(HttpResponseMessage response)
         {
             this.response = response;
             Headers = response.Headers;

--- a/arangodb-net-standard/Transport/Http/HttpApiTransport.cs
+++ b/arangodb-net-standard/Transport/Http/HttpApiTransport.cs
@@ -438,7 +438,6 @@ namespace ArangoDBNetStandard.Transport.Http
         /// </summary>
         public void Dispose()
         {
-            _client.Dispose();
         }
     }
 }


### PR DESCRIPTION
1. Don't dispose external resources like HttpClient. They can be injected and controlled by DI system.
2. Don't force IArangoDBClient interface inherit IDisposable. It doesn't contain anything Disposable.
3. HttpApiClientResponse is internal resource manager class