### PR TITLE
Add missing properties to Post, Put and Patch document query objects

### DIFF
--- a/arangodb-net-standard/DocumentApi/Models/DeleteDocumentQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/DeleteDocumentQuery.cs
@@ -27,6 +27,13 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         /// </summary>
         public bool? Silent { get; set; }
 
+        /// <summary>
+        /// Whether to delete an existing entry from the in-memory 
+        /// edge cache and refill it with another edge if an edge
+        /// document is removed.
+        /// </summary>
+        public bool? RefillIndexCaches { get; set; }
+
         internal string ToQueryString()
         {
             var queryParams = new List<string>();
@@ -41,6 +48,10 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (Silent != null)
             {
                 queryParams.Add("silent=" + Silent.ToString().ToLower());
+            }
+            if (RefillIndexCaches != null)
+            {
+                queryParams.Add("refillIndexCaches=" + RefillIndexCaches.ToString().ToLower());
             }
             return string.Join("&", queryParams);
         }

--- a/arangodb-net-standard/DocumentApi/Models/DeleteDocumentsQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/DeleteDocumentsQuery.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
@@ -31,6 +32,13 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         /// </summary>
         public bool? Silent { get; set; }
 
+        /// <summary>
+        /// Whether to delete an existing entry from the in-memory 
+        /// edge cache and refill it with another edge if an edge
+        /// document is removed.
+        /// </summary>
+        public bool? RefillIndexCaches { get; set; }
+
         internal string ToQueryString()
         {
             var queryParams = new List<string>();
@@ -49,6 +57,10 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (Silent != null)
             {
                 queryParams.Add("silent=" + Silent.ToString().ToLower());
+            }
+            if (RefillIndexCaches != null)
+            {
+                queryParams.Add("refillIndexCaches=" + RefillIndexCaches.ToString().ToLower());
             }
             return string.Join("&", queryParams);
         }

--- a/arangodb-net-standard/DocumentApi/Models/OverwriteModes.cs
+++ b/arangodb-net-standard/DocumentApi/Models/OverwriteModes.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ArangoDBNetStandard.DocumentApi.Models
+{   
+    /// <summary>
+     /// Defines values for document overwrite modes
+     /// Possible value for <see cref="PostDocumentsQuery.OverwriteMode"/>
+     /// </summary>
+    public static class OverwriteModes
+    {
+        /// <summary>
+        /// If a document with the specified _key value exists already,
+        /// nothing is done and no write operation is carried out.
+        /// The insert operation returns success in this case. 
+        /// This mode does not support returning the old document
+        /// version using <see cref="PostDocumentsQuery.ReturnOld"/>. 
+        /// When using <see cref="PostDocumentsQuery.ReturnNew"/>, null 
+        /// is returned in case the document already existed.
+        /// </summary>
+        public const string Ignore = "ignore";
+
+        /// <summary>
+        /// If a document with the specified _key value exists
+        /// already, it is overwritten with the specified document
+        /// value. This mode is also used when no overwrite mode
+        /// is specified but the <see cref="PostDocumentsQuery.Overwrite"/> 
+        /// flag is set to true.
+        /// </summary>
+        public const string Replace = "replace";
+
+        /// <summary>
+        /// If a document with the specified _key value exists
+        /// already, it is patched (partially updated) with the
+        /// specified document value. The overwrite mode can be 
+        /// further controlled via the 
+        /// <see cref="PostDocumentsQuery.KeepNull"/> and 
+        /// <see cref="PostDocumentsQuery.MergeObjects"/>
+        /// parameters.
+        /// </summary>
+        public const string Update = "update";
+
+        /// <summary>
+        /// If a document with the specified _key value exists 
+        /// already, return a unique constraint violation error
+        /// so that the insert operation fails. This is also 
+        /// the default behavior in case the overwrite mode is
+        /// not set, and the <see cref="PostDocumentsQuery.Overwrite"/>
+        /// flag is false or not set either.
+        /// </summary>
+        public const string Conflict = "conflict";
+    }
+}

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentQuery.cs
@@ -2,21 +2,66 @@
 
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
+    /// <summary>
+    /// Represents query parameters used when updating a document.
+    /// </summary>
     public class PatchDocumentQuery
     {
+        /// <summary>
+        /// If the intention is to delete existing attributes with the patch command,
+        /// this query parameter can be used with a value of false.
+        /// This will modify the behavior of the patch command to remove any attributes
+        /// from the existing document that are contained in the patch document with an attribute value of null.
+        /// </summary>
         public bool? KeepNull { get; set; }
 
+        /// <summary>
+        /// Controls whether objects (not arrays) will be merged
+        /// if present in both the existing and the patch document.
+        /// If set to false, the value in the patch document will
+        /// overwrite the existing document’s value.
+        /// If set to true, objects will be merged.
+        /// The default is true.
+        /// </summary>
         public bool? MergeObjects { get; set; }
 
+        /// <summary>
+        /// Wait until the new documents have been synced to disk.
+        /// </summary>
         public bool? WaitForSync { get; set; }
 
+        /// <summary>
+        /// By default, or if this is set to true, the _rev attributes
+        /// in the given documents are ignored.
+        /// If this is set to false, then any _rev attribute given
+        /// in a body document is taken as a precondition.
+        /// The document is only updated if the current revision is the one specified.
+        /// </summary>
         public bool? IgnoreRevs { get; set; }
 
+        /// <summary>
+        /// Return additionally the complete previous revision
+        /// of the changed documents in the result.
+        /// </summary>
         public bool? ReturnOld { get; set; }
 
+        /// <summary>
+        /// Return additionally the complete new documents in the result.
+        /// </summary>
         public bool? ReturnNew { get; set; }
 
+        /// <summary>
+        /// If set to true, an empty object will be returned as response.
+        /// No meta-data will be returned for the created document.
+        /// This option can be used to save some network traffic.
+        /// </summary>
         public bool? Silent { get; set; }
+
+        /// <summary>
+        /// Whether to update an existing entry in the in-memory edge 
+        /// cache if an edge document is updated.
+        /// </summary>
+        public bool? RefillIndexCaches { get; set; }
 
         internal string ToQueryString()
         {
@@ -48,6 +93,10 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (IgnoreRevs != null)
             {
                 queryParams.Add("ignoreRevs=" + IgnoreRevs.ToString().ToLower());
+            }
+            if (RefillIndexCaches != null)
+            {
+                queryParams.Add("refillIndexCaches=" + RefillIndexCaches.ToString().ToLower());
             }
             return string.Join("&", queryParams);
         }

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentsQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentsQuery.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
@@ -57,6 +58,12 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         /// </summary>
         public bool? Silent { get; set; }
 
+        /// <summary>
+        /// Whether to update an existing entry in the in-memory edge 
+        /// cache if an edge document is updated.
+        /// </summary>
+        public bool? RefillIndexCaches { get; set; }
+
         internal string ToQueryString()
         {
             var queryParams = new List<string>();
@@ -87,6 +94,10 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (Silent != null)
             {
                 queryParams.Add("silent=" + Silent.ToString().ToLower());
+            }
+            if (RefillIndexCaches != null)
+            {
+                query.Add("refillIndexCaches=" + RefillIndexCaches.ToString().ToLower());
             }
             return string.Join("&", queryParams);
         }

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentsQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentsQuery.cs
@@ -97,7 +97,7 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             }
             if (RefillIndexCaches != null)
             {
-                query.Add("refillIndexCaches=" + RefillIndexCaches.ToString().ToLower());
+                queryParams.Add("refillIndexCaches=" + RefillIndexCaches.ToString().ToLower());
             }
             return string.Join("&", queryParams);
         }

--- a/arangodb-net-standard/DocumentApi/Models/PostDocumentsQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PostDocumentsQuery.cs
@@ -31,12 +31,14 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         public bool? Silent { get; set; }
 
         /// <summary>
-        /// If a document already exists, whether to overwrite (replace) the document rather than respond with error.
+        /// If a document already exists, whether to overwrite (replace) 
+        /// the document rather than respond with error.
         /// </summary>
         public bool? Overwrite { get; set; }
 
         /// <summary>
-        /// This option supersedes <see cref="Overwrite"/> and offers the several modes.
+        /// This option supersedes <see cref="Overwrite"/> and offers 
+        /// the several modes listed in <see cref="OverwriteModes"/>.
         /// </summary>
         public string OverwriteMode { get; set; }
 

--- a/arangodb-net-standard/DocumentApi/Models/PostDocumentsQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PostDocumentsQuery.cs
@@ -8,6 +8,9 @@ namespace ArangoDBNetStandard.DocumentApi.Models
     /// </summary>
     public class PostDocumentsQuery
     {
+        /// <summary>
+        /// Wait until document has been synced to disk.
+        /// </summary>
         public bool? WaitForSync { get; set; }
 
         /// <summary>
@@ -31,6 +34,41 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         /// If a document already exists, whether to overwrite (replace) the document rather than respond with error.
         /// </summary>
         public bool? Overwrite { get; set; }
+
+        /// <summary>
+        /// This option supersedes <see cref="Overwrite"/> and offers the several modes.
+        /// </summary>
+        public string OverwriteMode { get; set; }
+
+        /// <summary>
+        /// If the intention is to delete existing attributes 
+        /// with the update-insert command, the URL query 
+        /// parameter keepNull can be used with a value of 
+        /// false. This modifies the behavior of the patch 
+        /// command to remove any attributes from the 
+        /// existing document that are contained in the patch 
+        /// document with an attribute value of null. 
+        /// This option controls the update-insert behavior only.
+        /// </summary>
+        public bool? KeepNull { get; set; }
+
+        /// <summary>
+        /// Controls whether objects (not arrays) are 
+        /// merged if present in both, the existing and
+        /// the update-insert document. If set to false,
+        /// the value in the patch document overwrites 
+        /// the existing document’s value. If set to true, 
+        /// objects are merged. The default is true. 
+        /// This option controls the update-insert 
+        /// behavior only.
+        /// </summary>
+        public bool? MergeObjects { get; set; }
+
+        /// <summary>
+        /// Whether to add a new entry to the in-memory
+        /// edge cache if an edge document is inserted.
+        /// </summary>
+        public bool? RefillIndexCaches { get; set; }
 
         /// <summary>
         /// Get the set of options in a format suited to a URL query string.
@@ -58,6 +96,22 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (Overwrite != null)
             {
                 query.Add("overwrite=" + Overwrite.ToString().ToLower());
+            }
+            if (OverwriteMode != null)
+            {
+                query.Add("overwriteMode =" + OverwriteMode.ToLower());
+            }
+            if (KeepNull != null)
+            {
+                query.Add("keepNull=" + KeepNull.ToString().ToLower());
+            }
+            if (MergeObjects != null)
+            {
+                query.Add("mergeObjects=" + MergeObjects.ToString().ToLower());
+            }
+            if (RefillIndexCaches != null)
+            {
+                query.Add("refillIndexCaches=" + RefillIndexCaches.ToString().ToLower());
             }
             return string.Join("&", query);
         }

--- a/arangodb-net-standard/DocumentApi/Models/PutDocumentQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PutDocumentQuery.cs
@@ -43,6 +43,12 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         public bool? Silent { get; set; }
 
         /// <summary>
+        /// Whether to update an existing entry in the in-memory 
+        /// edge cache if an edge document is replaced.
+        /// </summary>
+        public bool? RefillIndexCaches { get; set; }
+
+        /// <summary>
         /// Get the set of options in a format suited to a URL query string.
         /// </summary>
         /// <returns></returns>
@@ -68,6 +74,10 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (Silent != null)
             {
                 query.Add("silent=" + Silent.ToString().ToLower());
+            }
+            if (RefillIndexCaches != null)
+            {
+                query.Add("refillIndexCaches=" + RefillIndexCaches.ToString().ToLower());
             }
             return string.Join("&", query);
         }

--- a/arangodb-net-standard/DocumentApi/Models/PutDocumentsQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PutDocumentsQuery.cs
@@ -44,6 +44,12 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         public bool? Silent { get; set; }
 
         /// <summary>
+        /// Whether to update an existing entry in the in-memory 
+        /// edge cache if an edge document is replaced.
+        /// </summary>
+        public bool? RefillIndexCaches { get; set; }
+
+        /// <summary>
         /// Get the set of options in a format suited to a URL query string.
         /// </summary>
         /// <returns></returns>
@@ -69,6 +75,10 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (Silent != null)
             {
                 query.Add("silent=" + Silent.ToString().ToLower());
+            }
+            if (RefillIndexCaches != null)
+            {
+                query.Add("refillIndexCaches=" + RefillIndexCaches.ToString().ToLower());
             }
             return string.Join("&", query);
         }


### PR DESCRIPTION
- Fixes #255 
- Add missing properties to Post, Put and Patch document query objects
- Updated the query objects as per specifications here: https://www.arangodb.com/docs/stable/http/document-working-with-documents.html#update-document