### PR TITLE
Support overload control in API requests

### DIFF
--- a/arangodb-net-standard/AdminApi/AdminApiClient.cs
+++ b/arangodb-net-standard/AdminApi/AdminApiClient.cs
@@ -53,19 +53,20 @@ namespace ArangoDBNetStandard.AdminApi
         /// </summary>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <param name="query">Query string parameters</param>
+        /// <param name="headers">Headers for the request</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#read-global-logs-from-the-server
         /// </remarks>
-        public virtual async Task<GetLogsResponse> GetLogsAsync(GetLogsQuery query = null, CancellationToken token = default)
+        public virtual async Task<GetLogsResponse> GetLogsAsync(GetLogsQuery query = null, ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = $"{_adminApiPath}/log/entries";
             if (query != null)
             {
                 uri += '?' + query.ToQueryString();
             }
-            using (var response = await _client.GetAsync(uri, null, token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri, headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -80,17 +81,18 @@ namespace ArangoDBNetStandard.AdminApi
         /// Reloads the routing table.
         /// POST /_admin/routing/reload
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#reloads-the-routing-information
         /// </remarks>
-        public virtual async Task<bool> PostReloadRoutingInfoAsync(CancellationToken token = default)
+        public virtual async Task<bool> PostReloadRoutingInfoAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = $"{_adminApiPath}/routing/reload";
             var body = new byte[] { };
-            using (var response = await _client.PostAsync(uri, body, null, token).ConfigureAwait(false))
+            using (var response = await _client.PostAsync(uri, body, headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -105,16 +107,17 @@ namespace ArangoDBNetStandard.AdminApi
         /// The method will fail if the server is not running in cluster mode.
         /// GET /_admin/server/id
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#return-id-of-a-server-in-a-cluster
         /// </remarks>
-        public virtual async Task<GetServerIdResponse> GetServerIdAsync(CancellationToken token = default)
+        public virtual async Task<GetServerIdResponse> GetServerIdAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = $"{_adminApiPath}/server/id";
-            using (var response = await _client.GetAsync(uri, null, token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri, headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -129,16 +132,17 @@ namespace ArangoDBNetStandard.AdminApi
         /// Retrieves the role of the server in a cluster.
         /// GET /_admin/server/role
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see
         /// https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#return-the-role-of-a-server-in-a-cluster
         /// </remarks>
-        public virtual async Task<GetServerRoleResponse> GetServerRoleAsync(CancellationToken token = default)
+        public virtual async Task<GetServerRoleResponse> GetServerRoleAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = $"{_adminApiPath}/server/role";
-            using (var response = await _client.GetAsync(uri, null, token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri, headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -153,16 +157,17 @@ namespace ArangoDBNetStandard.AdminApi
         /// Retrieves the server database engine type.
         /// GET /_api/engine
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/miscellaneous-functions.html#return-server-database-engine-type
         /// </remarks>
-        public virtual async Task<GetServerEngineTypeResponse> GetServerEngineTypeAsync(CancellationToken token = default)
+        public virtual async Task<GetServerEngineTypeResponse> GetServerEngineTypeAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = "_api/engine";
-            using (var response = await _client.GetAsync(uri, null, token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri, headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -178,20 +183,21 @@ namespace ArangoDBNetStandard.AdminApi
         /// GET /_api/version
         /// </summary>
         /// <param name="query">Query string parameters</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/miscellaneous-functions.html#return-server-version
         /// </remarks>
-        public virtual async Task<GetServerVersionResponse> GetServerVersionAsync(GetServerVersionQuery query = null, CancellationToken token = default)
+        public virtual async Task<GetServerVersionResponse> GetServerVersionAsync(GetServerVersionQuery query = null, ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = "_api/version";
             if (query != null)
             {
                 uri += '?' + query.ToQueryString();
             }
-            using (var response = await _client.GetAsync(uri,null,token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri, headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -206,16 +212,17 @@ namespace ArangoDBNetStandard.AdminApi
         /// Retrieves the server license information.
         /// GET /_admin/license
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/3.9/administration-license.html
         /// </remarks>
-        public virtual async Task<GetLicenseResponse> GetLicenseAsync(CancellationToken token = default)
+        public virtual async Task<GetLicenseResponse> GetLicenseAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = $"{_adminApiPath}/license";
-            using (var response = await _client.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri, headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -232,13 +239,14 @@ namespace ArangoDBNetStandard.AdminApi
         /// </summary>
         /// <param name="licenseKey">The new license key</param>
         /// <param name="query">Query string parameters</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/3.9/administration-license.html
         /// </remarks>
-        public virtual async Task<PutLicenseResponse> PutLicenseAsync(string licenseKey, PutLicenseQuery query = null, CancellationToken token = default)
+        public virtual async Task<PutLicenseResponse> PutLicenseAsync(string licenseKey, PutLicenseQuery query = null, ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = $"{_adminApiPath}/license";
             if (query != null)
@@ -246,7 +254,7 @@ namespace ArangoDBNetStandard.AdminApi
                 uri += '?' + query.ToQueryString();
             }
             var content = await GetContentAsync(licenseKey, new ApiClientSerializationOptions(true, true));
-            using (var response = await _client.PutAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _client.PutAsync(uri, content, headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/AdminApi/IAdminApiClient.cs
+++ b/arangodb-net-standard/AdminApi/IAdminApiClient.cs
@@ -16,87 +16,94 @@ namespace ArangoDBNetStandard.AdminApi
         /// Works on ArangoDB 3.8 or later.
         /// </summary>
         /// <param name="query">Query string parameters</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#read-global-logs-from-the-server
         /// </remarks>
-        Task<GetLogsResponse> GetLogsAsync(GetLogsQuery query = null, CancellationToken token = default);
+        Task<GetLogsResponse> GetLogsAsync(GetLogsQuery query = null, ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Reloads the routing table.
         /// POST /_admin/routing/reload
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#reloads-the-routing-information
         /// </remarks>
-        Task<bool> PostReloadRoutingInfoAsync(CancellationToken token = default);
+        Task<bool> PostReloadRoutingInfoAsync(ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Retrieves the internal id of the server.
         /// The method will fail if the server is not running in cluster mode.
         /// GET /_admin/server/id
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#return-id-of-a-server-in-a-cluster
         /// </remarks>
-        Task<GetServerIdResponse> GetServerIdAsync(CancellationToken token = default);
+        Task<GetServerIdResponse> GetServerIdAsync(ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Retrieves the role of the server in a cluster.
         /// GET /_admin/server/role
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see
         /// https://www.arangodb.com/docs/stable/http/administration-and-monitoring.html#return-the-role-of-a-server-in-a-cluster
         /// </remarks>
-        Task<GetServerRoleResponse> GetServerRoleAsync(CancellationToken token = default);
+        Task<GetServerRoleResponse> GetServerRoleAsync(ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Retrieves the server database engine type.
         /// GET /_api/engine
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/miscellaneous-functions.html#return-server-database-engine-type
         /// </remarks>
-        Task<GetServerEngineTypeResponse> GetServerEngineTypeAsync(CancellationToken token = default);
+        Task<GetServerEngineTypeResponse> GetServerEngineTypeAsync(ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Retrieves the server version.
         /// GET /_api/version
         /// </summary>
         /// <param name="query">Query string parameters</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/stable/http/miscellaneous-functions.html#return-server-version
         /// </remarks>
-        Task<GetServerVersionResponse> GetServerVersionAsync(GetServerVersionQuery query = null, CancellationToken token = default);
-        
+        Task<GetServerVersionResponse> GetServerVersionAsync(GetServerVersionQuery query = null, ApiHeaderProperties headers = null, CancellationToken token = default);
+
         /// <summary>
         /// Retrieves the server license information.
         /// GET /_admin/license
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/3.9/administration-license.html
         /// </remarks>
-        Task<GetLicenseResponse> GetLicenseAsync(CancellationToken token = default);
+        Task<GetLicenseResponse> GetLicenseAsync(ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Sets a new license key.
@@ -104,12 +111,13 @@ namespace ArangoDBNetStandard.AdminApi
         /// </summary>
         /// <param name="licenseKey">The new license key</param>
         /// <param name="query">Query string parameters</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>
         /// For further information see 
         /// https://www.arangodb.com/docs/3.9/administration-license.html
         /// </remarks>
-        Task<PutLicenseResponse> PutLicenseAsync(string licenseKey, PutLicenseQuery query = null, CancellationToken token = default);
+        Task<PutLicenseResponse> PutLicenseAsync(string licenseKey, PutLicenseQuery query = null, ApiHeaderProperties headers = null, CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/AnalyzerApi/AnalyzerApiClient.cs
+++ b/arangodb-net-standard/AnalyzerApi/AnalyzerApiClient.cs
@@ -52,12 +52,13 @@ namespace ArangoDBNetStandard.AnalyzerApi
         /// Fetch the list of available Analyzer definitions.
         /// GET /_api/analyzer
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<GetAllAnalyzersResponse> GetAllAnalyzersAsync(CancellationToken token = default)
+        public virtual async Task<GetAllAnalyzersResponse> GetAllAnalyzersAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = _analyzerApiPath;
-            using (var response = await _client.GetAsync(uri, null, token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -73,9 +74,10 @@ namespace ArangoDBNetStandard.AnalyzerApi
         /// POST /_api/analyzer
         /// </summary>
         /// <param name="body">The properties of the new analyzer.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<Analyzer> PostAnalyzerAsync(Analyzer body, CancellationToken token = default)
+        public virtual async Task<Analyzer> PostAnalyzerAsync(Analyzer body, ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             if (body == null)
             {
@@ -83,7 +85,7 @@ namespace ArangoDBNetStandard.AnalyzerApi
             }
             var uri = _analyzerApiPath;
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PostAsync(uri, content, null, token).ConfigureAwait(false))
+            using (var response = await _client.PostAsync(uri, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -99,16 +101,17 @@ namespace ArangoDBNetStandard.AnalyzerApi
         /// GET /_api/analyzer/{analyzer-name}
         /// </summary>
         /// <param name="analyzerName">The name of the analyzer</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<GetAnalyzerResponse> GetAnalyzerAsync(string analyzerName, CancellationToken token = default)
+        public virtual async Task<GetAnalyzerResponse> GetAnalyzerAsync(string analyzerName, ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             if (string.IsNullOrEmpty(analyzerName))
             {
                 throw new ArgumentException("Analyzer name is required", nameof(analyzerName));
             }
             string uri = _analyzerApiPath + '/' + WebUtility.UrlEncode(analyzerName);
-            using (var response = await _client.GetAsync(uri, null, token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -124,16 +127,17 @@ namespace ArangoDBNetStandard.AnalyzerApi
         /// DELETE /_api/analyzer/{analyzer-name}
         /// </summary>
         /// <param name="analyzerName">The name of the analyzer</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<DeleteAnalyzerResponse> DeleteAnalyzerAsync(string analyzerName, CancellationToken token = default)
+        public virtual async Task<DeleteAnalyzerResponse> DeleteAnalyzerAsync(string analyzerName, ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             if (string.IsNullOrEmpty(analyzerName))
             {
                 throw new ArgumentException("Analyzer name is required", nameof(analyzerName));
             }
             string uri = _analyzerApiPath + '/' + WebUtility.UrlEncode(analyzerName);
-            using (var response = await _client.DeleteAsync(uri,null,token).ConfigureAwait(false))
+            using (var response = await _client.DeleteAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection() ,token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/AnalyzerApi/IAnalyzerApiClient.cs
+++ b/arangodb-net-standard/AnalyzerApi/IAnalyzerApiClient.cs
@@ -13,35 +13,39 @@ namespace ArangoDBNetStandard.AnalyzerApi
         /// Fetch the list of available Analyzer definitions.
         /// GET /_api/analyzer
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetAllAnalyzersResponse> GetAllAnalyzersAsync(CancellationToken token = default);
+        Task<GetAllAnalyzersResponse> GetAllAnalyzersAsync(ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Creates a new Analyzer based on the provided definition
         /// POST /_api/analyzer
         /// </summary>
         /// <param name="body">The properties of the new analyzer.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<Analyzer> PostAnalyzerAsync(Analyzer body, CancellationToken token = default);
+        Task<Analyzer> PostAnalyzerAsync(Analyzer body, ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Fetches the definition of the specified analyzer.
         /// GET /_api/analyzer/{analyzer-name}
         /// </summary>
         /// <param name="analyzerName">The name of the analyzer</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetAnalyzerResponse> GetAnalyzerAsync(string analyzerName, CancellationToken token = default);
+        Task<GetAnalyzerResponse> GetAnalyzerAsync(string analyzerName, ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Deletes an Analyzer.
         /// DELETE /_api/analyzer/{analyzer-name}
         /// </summary>
         /// <param name="analyzerName">The name of the analyzer</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<DeleteAnalyzerResponse> DeleteAnalyzerAsync(string analyzerName, CancellationToken token = default);
+        Task<DeleteAnalyzerResponse> DeleteAnalyzerAsync(string analyzerName, ApiHeaderProperties headers = null, CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/ApiHeaderProperties.cs
+++ b/arangodb-net-standard/ApiHeaderProperties.cs
@@ -19,6 +19,16 @@ namespace ArangoDBNetStandard
         public bool? AllowReadFromFollowers { get; set; }
 
         /// <summary>
+        /// Set max queue time limit.
+        /// When executing a request, specify a maximal 
+        /// queue time in seconds before the request is 
+        /// canceled and removed from the queue.
+        /// The value 0 is ignored by the server.
+        /// Introduced in ArangoDB 3.9
+        /// </summary>
+        public decimal? MaxQueueTimeLimit { get; set; }
+
+        /// <summary>
         /// Any other headers you wish to add based on
         /// the specifications of the API operation.
         /// </summary>
@@ -35,6 +45,11 @@ namespace ArangoDBNetStandard
             if (AllowReadFromFollowers != null)
             {
                 collection.Add(CustomHttpHeaders.ReadFromFollowersHeader, AllowReadFromFollowers.Value.ToString());
+            }
+
+            if (MaxQueueTimeLimit != null)
+            {
+                collection.Add(CustomHttpHeaders.MaxQueueTimeLimitHeader, MaxQueueTimeLimit.Value.ToString());
             }
 
             if (OtherHeaders != null && OtherHeaders.Count > 0)

--- a/arangodb-net-standard/AqlFunctionApi/AqlFunctionApiClient.cs
+++ b/arangodb-net-standard/AqlFunctionApi/AqlFunctionApiClient.cs
@@ -53,15 +53,16 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// POST /_api/aqlfunction
         /// </summary>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostAqlFunctionResponse> PostAqlFunctionAsync(
-            PostAqlFunctionBody body,
+            PostAqlFunctionBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
 
-            using (var response = await _transport.PostAsync(_apiPath, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(_apiPath, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -78,11 +79,12 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// </summary>
         /// <param name="name">The name of the function or function group (namespace).</param>
         /// <param name="query">The query parameters of the request.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteAqlFunctionResponse> DeleteAqlFunctionAsync(
             string name,
-            DeleteAqlFunctionQuery query = null,
+            DeleteAqlFunctionQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _apiPath + '/' + WebUtility.UrlEncode(name);
@@ -92,7 +94,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
                 uri += "?" + query.ToQueryString();
             }
 
-            using (var response = await _transport.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -107,10 +109,11 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Get all registered AQL user functions.
         /// </summary>
         /// <param name="query">Query string options for the task.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetAqlFunctionsResponse> GetAqlFunctionsAsync(
-            GetAqlFunctionsQuery query = null,
+            GetAqlFunctionsQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _apiPath;
@@ -120,7 +123,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
                 uri += "?" + query.ToQueryString();
             }
 
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -136,10 +139,11 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// POST /_api/explain
         /// </summary>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostExplainAqlQueryResponse> PostExplainAqlQueryAsync(
-            PostExplainAqlQueryBody body,
+            PostExplainAqlQueryBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (body == null)
@@ -150,7 +154,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
             string uri = "_api/explain";
 
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _transport.PostAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -166,10 +170,11 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// POST /_api/query
         /// </summary>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostParseAqlQueryResponse> PostParseAqlQueryAsync(
-            PostParseAqlQueryBody body,
+            PostParseAqlQueryBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (body == null)
@@ -180,7 +185,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
             string uri = "_api/query";
 
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _transport.PostAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -202,6 +207,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// the specified query in all databases, not just the 
         /// selected one.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Kills a running query in the currently selected database. 
@@ -212,7 +218,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// <returns></returns>
         public virtual async Task<ResponseBase> DeleteKillRunningAqlQueryAsync(
             string queryId,
-            DeleteKillRunningAqlQueryQuery query = null,
+            DeleteKillRunningAqlQueryQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(queryId))
@@ -227,7 +233,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
                 uri += "?" + query.ToQueryString();
             }
 
-            using (var response = await _transport.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -249,10 +255,11 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Using the parameter is only allowed in the system database
         /// and with superuser privileges.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<ResponseBase> DeleteClearSlowAqlQueriesAsync(
-            DeleteClearSlowAqlQueriesQuery query = null,
+            DeleteClearSlowAqlQueriesQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = "_api/query/slow";
@@ -262,7 +269,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
                 uri += "?" + query.ToQueryString();
             }
 
-            using (var response = await _transport.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -284,6 +291,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Using the parameter is only allowed in the system database
         /// and with superuser privileges.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns an array containing the last AQL queries that are 
@@ -295,7 +303,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// </remarks>
         /// <returns></returns>
         public virtual async Task<List<SlowAqlQuery>> GetSlowAqlQueriesAsync(
-            GetSlowAqlQueriesQuery query = null,
+            GetSlowAqlQueriesQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = "_api/query/slow";
@@ -305,7 +313,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
                 uri += "?" + query.ToQueryString();
             }
 
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -322,14 +330,15 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Clears the query results cache for the current database
         /// DELETE /_api/query-cache
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<ResponseBase> DeleteClearAqlQueryCacheAsync(
+        public virtual async Task<ResponseBase> DeleteClearAqlQueryCacheAsync(ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = "_api/query-cache";
 
-            using (var response = await _transport.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -344,17 +353,18 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Gets a list of the stored results in the AQL query results cache.
         /// GET /_api/query-cache/entries
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns an array containing the AQL query results currently 
         /// stored in the query results cache of the selected database.
         /// </remarks>
         /// <returns></returns>
-        public virtual async Task<List<CachedAqlQueryResult>> GetCachedAqlQueryResultsAsync(
+        public virtual async Task<List<CachedAqlQueryResult>> GetCachedAqlQueryResultsAsync(ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = "_api/query-cache/entries";
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -368,16 +378,17 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// <summary>
         /// Gets the global configuration for the AQL query results cache.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns the global AQL query results cache configuration.
         /// </remarks>
         /// <returns></returns>
-        public virtual async Task<QueryCacheGlobalProperties> GetQueryCacheGlobalPropertiesAsync(
+        public virtual async Task<QueryCacheGlobalProperties> GetQueryCacheGlobalPropertiesAsync(ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = "_api/query-cache/properties";
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -393,6 +404,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// PUT /_api/query-cache/properties
         /// </summary>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// After the properties have been changed, the current set of properties 
@@ -401,7 +413,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// </remarks>
         /// <returns></returns>
         public virtual async Task<QueryCacheGlobalProperties> PutAdjustQueryCacheGlobalPropertiesAsync(
-            PutAdjustQueryCacheGlobalPropertiesBody body,
+            PutAdjustQueryCacheGlobalPropertiesBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (body == null)
@@ -412,7 +424,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
             string uri = "_api/query-cache/properties";
 
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _transport.PutAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uri, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -427,13 +439,14 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Gets the current query tracking configuration. 
         /// GET /_api/query/properties
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<QueryTrackingConfiguration> GetQueryTrackingConfigurationAsync(
+        public virtual async Task<QueryTrackingConfiguration> GetQueryTrackingConfigurationAsync(ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = "_api/query/properties";
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -453,10 +466,11 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// the current set of properties will be returned.
         /// </remarks>
         /// <param name="body">The body of the request containing required configuration properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<QueryTrackingConfiguration> PutChangeQueryTrackingConfigurationAsync(
-            PutChangeQueryTrackingConfigurationBody body,
+            PutChangeQueryTrackingConfigurationBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (body == null)
@@ -467,7 +481,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
             string uri = "_api/query/properties";
 
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _transport.PutAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uri, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -482,13 +496,14 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Gets a list of currently running AQL queries.
         /// </summary>
         /// <param name="query">Query string options for the task.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns the global AQL query results cache configuration.
         /// </remarks>
         /// <returns></returns>
         public virtual async Task<List<RunningAqlQuery>> GetCurrentlyRunningAqlQueriesAsync(
-            GetCurrentlyRunningAqlQueriesQuery query = null,
+            GetCurrentlyRunningAqlQueriesQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = "_api/query/current";
@@ -498,7 +513,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
                 uri += "?" + query.ToQueryString();
             }
 
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -513,17 +528,18 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Gets the available optimizer rules for AQL queries
         /// GET /_api/query/rules
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns an array of objects that contain the name of each available 
         /// rule and its respective flags.
         /// </remarks>
         /// <returns></returns>
-        public virtual async Task<List<GetQueryRule>> GetQueryRulesAsync(CancellationToken token = default)
+        public virtual async Task<List<GetQueryRule>> GetQueryRulesAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = "_api/query/rules";
 
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri, webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/AqlFunctionApi/IAqlFunctionApiClient.cs
+++ b/arangodb-net-standard/AqlFunctionApi/IAqlFunctionApiClient.cs
@@ -16,9 +16,10 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// POST /_api/aqlfunction
         /// </summary>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<PostAqlFunctionResponse> PostAqlFunctionAsync(PostAqlFunctionBody body,
+        Task<PostAqlFunctionResponse> PostAqlFunctionAsync(PostAqlFunctionBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -26,22 +27,24 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// DELETE /_api/aqlfunction/{name}
         /// </summary>
         /// <param name="name">The name of the function or function group (namespace).</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="query">The query parameters of the request.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<DeleteAqlFunctionResponse> DeleteAqlFunctionAsync(
             string name,
-            DeleteAqlFunctionQuery query = null,
+            DeleteAqlFunctionQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Get all registered AQL user functions.
         /// </summary>
         /// <param name="query">Query string options for the task.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetAqlFunctionsResponse> GetAqlFunctionsAsync(
-            GetAqlFunctionsQuery query = null,
+            GetAqlFunctionsQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -49,10 +52,11 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// POST /_api/explain
         /// </summary>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PostExplainAqlQueryResponse> PostExplainAqlQueryAsync(
-            PostExplainAqlQueryBody body,
+            PostExplainAqlQueryBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -60,10 +64,11 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// POST /_api/query
         /// </summary>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PostParseAqlQueryResponse> PostParseAqlQueryAsync(
-            PostParseAqlQueryBody body,
+            PostParseAqlQueryBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -77,6 +82,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// the specified query in all databases, not just the 
         /// selected one.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Kills a running query in the currently selected database. 
@@ -87,7 +93,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// <returns></returns>
         Task<ResponseBase> DeleteKillRunningAqlQueryAsync(
             string queryId,
-         DeleteKillRunningAqlQueryQuery query = null,
+         DeleteKillRunningAqlQueryQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -101,10 +107,11 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Using the parameter is only allowed in the system database
         /// and with superuser privileges.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<ResponseBase> DeleteClearSlowAqlQueriesAsync(
-           DeleteClearSlowAqlQueriesQuery query = null,
+           DeleteClearSlowAqlQueriesQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -118,6 +125,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Using the parameter is only allowed in the system database
         /// and with superuser privileges.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns an array containing the last AQL queries that are 
@@ -129,40 +137,43 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// </remarks>
         /// <returns></returns>
         Task<List<SlowAqlQuery>> GetSlowAqlQueriesAsync(
-           GetSlowAqlQueriesQuery query = null,
+           GetSlowAqlQueriesQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Clears the query results cache for the current database
         /// DELETE /_api/query-cache
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<ResponseBase> DeleteClearAqlQueryCacheAsync(
+        Task<ResponseBase> DeleteClearAqlQueryCacheAsync(ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Gets a list of the stored results in the AQL query results cache.
         /// GET /_api/query-cache/entries
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns an array containing the AQL query results currently 
         /// stored in the query results cache of the selected database.
         /// </remarks>
         /// <returns></returns>
-        Task<List<CachedAqlQueryResult>> GetCachedAqlQueryResultsAsync(
+        Task<List<CachedAqlQueryResult>> GetCachedAqlQueryResultsAsync(ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Gets the global configuration for the AQL query results cache.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns the global AQL query results cache configuration.
         /// </remarks>
         /// <returns></returns>
-        Task<QueryCacheGlobalProperties> GetQueryCacheGlobalPropertiesAsync(
+        Task<QueryCacheGlobalProperties> GetQueryCacheGlobalPropertiesAsync(ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -170,6 +181,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// PUT /_api/query-cache/properties
         /// </summary>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// After the properties have been changed, the current set of properties 
@@ -178,7 +190,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// </remarks>
         /// <returns></returns>
         Task<QueryCacheGlobalProperties> PutAdjustQueryCacheGlobalPropertiesAsync(
-          PutAdjustQueryCacheGlobalPropertiesBody body,
+          PutAdjustQueryCacheGlobalPropertiesBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
 
@@ -186,9 +198,10 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Gets the current query tracking configuration. 
         /// GET /_api/query/properties
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<QueryTrackingConfiguration> GetQueryTrackingConfigurationAsync(
+        Task<QueryTrackingConfiguration> GetQueryTrackingConfigurationAsync(ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -196,6 +209,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// PUT /_api/query/properties
         /// </summary>
         /// <param name="body">The body of the request containing required configuration properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// After the configuration properties have been changed, 
@@ -203,7 +217,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// </remarks>
         /// <returns></returns>
         Task<QueryTrackingConfiguration> PutChangeQueryTrackingConfigurationAsync(
-          PutChangeQueryTrackingConfigurationBody body,
+          PutChangeQueryTrackingConfigurationBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -211,26 +225,28 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// GET /_api/query/current
         /// </summary>
         /// <param name="query">Query string options for the task.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns the global AQL query results cache configuration.
         /// </remarks>
         /// <returns></returns>
         Task<List<RunningAqlQuery>> GetCurrentlyRunningAqlQueriesAsync(
-            GetCurrentlyRunningAqlQueriesQuery query = null,
+            GetCurrentlyRunningAqlQueriesQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Gets the available optimizer rules for AQL queries
         /// GET /_api/query/rules
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Returns an array of objects that contain the name of each available 
         /// rule and its respective flags.
         /// </remarks>
         /// <returns></returns>
-        Task<List<GetQueryRule>> GetQueryRulesAsync(
+        Task<List<GetQueryRule>> GetQueryRulesAsync(ApiHeaderProperties headers = null,
             CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/AqlFunctionApi/IAqlFunctionApiClient.cs
+++ b/arangodb-net-standard/AqlFunctionApi/IAqlFunctionApiClient.cs
@@ -33,7 +33,8 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// <returns></returns>
         Task<DeleteAqlFunctionResponse> DeleteAqlFunctionAsync(
             string name,
-            DeleteAqlFunctionQuery query = null, ApiHeaderProperties headers = null,
+            DeleteAqlFunctionQuery query = null, 
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>

--- a/arangodb-net-standard/BulkOperationsApi/BulkOperationsApiClient.cs
+++ b/arangodb-net-standard/BulkOperationsApi/BulkOperationsApiClient.cs
@@ -55,11 +55,13 @@ namespace ArangoDBNetStandard.BulkOperationsApi
         /// </summary>
         /// <param name="query">Options for the import.</param>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
             ImportDocumentsQuery query,
             ImportDocumentArraysBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (body == null)
@@ -90,7 +92,7 @@ namespace ArangoDBNetStandard.BulkOperationsApi
             {
                 sb.AppendLine(await GetContentStringAsync(valueArr, options).ConfigureAwait(false));
             }
-            return await PostImportDocumentArraysAsync(query, sb.ToString(),token)
+            return await PostImportDocumentArraysAsync(query, sb.ToString(),headers,token)
                 .ConfigureAwait(false);
         }
 
@@ -100,11 +102,12 @@ namespace ArangoDBNetStandard.BulkOperationsApi
         /// </summary>
         /// <param name="query">Options for the import.</param>
         /// <param name="jsonBody">The body of the request containing required value arrays.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
             ImportDocumentsQuery query,
-            string jsonBody,
+            string jsonBody, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (query == null)
@@ -125,7 +128,7 @@ namespace ArangoDBNetStandard.BulkOperationsApi
             string uriString = _bulkOperationsApiPath;
             uriString += "?" + query.ToQueryString();
             var content = Encoding.UTF8.GetBytes(jsonBody);
-            using (var response = await _transport.PostAsync(uriString, content,null,token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uriString, content,webHeaderCollection: headers?.ToWebHeaderCollection(),token).ConfigureAwait(false))
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
@@ -142,11 +145,12 @@ namespace ArangoDBNetStandard.BulkOperationsApi
         /// </summary>
         /// <param name="query">Options for the import.</param>
         /// <param name="body">The body of the request containing required objects.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync<T>(
             ImportDocumentsQuery query,
-            ImportDocumentObjectsBody<T> body,
+            ImportDocumentObjectsBody<T> body, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (query == null)
@@ -185,7 +189,7 @@ namespace ArangoDBNetStandard.BulkOperationsApi
                 //body should be one array of JSON objects
                 sb.Append(await GetContentStringAsync(body.Documents, options).ConfigureAwait(false));
             }
-            return await PostImportDocumentObjectsAsync(query, sb.ToString(),token)
+            return await PostImportDocumentObjectsAsync(query, sb.ToString(),headers, token)
                 .ConfigureAwait(false);
         }
 
@@ -197,11 +201,12 @@ namespace ArangoDBNetStandard.BulkOperationsApi
         /// </summary>
         /// <param name="query">Options for the import.</param>
         /// <param name="jsonBody">The body of the request containing the required JSON objects.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(
             ImportDocumentsQuery query,
-            string jsonBody,
+            string jsonBody, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (query == null)
@@ -227,7 +232,7 @@ namespace ArangoDBNetStandard.BulkOperationsApi
             string uriString = _bulkOperationsApiPath;
             uriString += "?" + query.ToQueryString();
             var content = Encoding.UTF8.GetBytes(jsonBody);
-            using (var response = await _transport.PostAsync(uriString, content,null,token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uriString, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/BulkOperationsApi/IBulkOperationsApiClient.cs
+++ b/arangodb-net-standard/BulkOperationsApi/IBulkOperationsApiClient.cs
@@ -16,11 +16,13 @@ namespace ArangoDBNetStandard.BulkOperationsApi
         /// </summary>
         /// <param name="query">Options for the import.</param>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
             ImportDocumentsQuery query,
             ImportDocumentArraysBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -31,11 +33,13 @@ namespace ArangoDBNetStandard.BulkOperationsApi
         /// </summary>
         /// <param name="query">Options for the import.</param>
         /// <param name="jsonBody">The body of the request containing required value arrays.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
             ImportDocumentsQuery query,
-            string jsonBody,
+            string jsonBody, 
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
 
@@ -45,11 +49,13 @@ namespace ArangoDBNetStandard.BulkOperationsApi
         /// </summary>
         /// <param name="query">Options for the import.</param>
         /// <param name="body">The body of the request containing required objects.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync<T>(
             ImportDocumentsQuery query,
-            ImportDocumentObjectsBody<T> body,
+            ImportDocumentObjectsBody<T> body, 
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -60,11 +66,13 @@ namespace ArangoDBNetStandard.BulkOperationsApi
         /// </summary>
         /// <param name="query">Options for the import.</param>
         /// <param name="jsonBody">The body of the request containing the required JSON objects.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(
             ImportDocumentsQuery query,
             string jsonBody,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
@@ -53,11 +53,13 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="body">Attributes of the new collection</param>
         /// <param name="options">Query string options for the task.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostCollectionResponse> PostCollectionAsync(
             PostCollectionBody body,
             PostCollectionQuery options = null,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uriString = _collectionApiPath;
@@ -66,7 +68,7 @@ namespace ArangoDBNetStandard.CollectionApi
                 uriString += "?" + options.ToQueryString();
             }
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _transport.PostAsync(uriString, content, null, token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uriString, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
@@ -81,14 +83,16 @@ namespace ArangoDBNetStandard.CollectionApi
         /// Deletes a collection.
         /// </summary>
         /// <param name="collectionName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteCollectionResponse> DeleteCollectionAsync(string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             using (var response = await _transport.DeleteAsync(
-                _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName), 
-                null,
+                _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName),
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
                 token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
@@ -158,9 +162,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET/_api/collection
         /// </summary>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetCollectionsResponse> GetCollectionsAsync(GetCollectionsQuery query = null,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uriString = _collectionApiPath;
@@ -168,7 +174,7 @@ namespace ArangoDBNetStandard.CollectionApi
             {
                 uriString += "?" + query.ToQueryString();
             }
-            using (var response = await _transport.GetAsync(uriString, null, token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uriString, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -184,14 +190,16 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET/_api/collection/{collection-name}
         /// </summary>
         /// <param name="collectionName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public async Task<GetCollectionResponse> GetCollectionAsync(string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             using (var response = await _transport.GetAsync(
-                _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName), 
-                null,
+                _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName),
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
                 token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
@@ -209,14 +217,16 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET /_api/collection/{collection-name}/properties
         /// </summary>
         /// <param name="collectionName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetCollectionPropertiesResponse> GetCollectionPropertiesAsync(string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             using (var response = await _transport.GetAsync(
                 _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/properties", 
-                null,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
                 token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
@@ -234,16 +244,18 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="collectionName"></param>
         /// <param name="body"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<RenameCollectionResponse> RenameCollectionAsync(string collectionName, RenameCollectionBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, false)).ConfigureAwait(false);
             using (var response = await _transport.PutAsync(
                 _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/rename", 
                 content,
-                null,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
                 token).ConfigureAwait(false))
            {
                 if (response.IsSuccessStatusCode)
@@ -261,14 +273,16 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET /_api/collection/{collection-name}/revision
         /// </summary>
         /// <param name="collectionName">Name of the collection</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetCollectionRevisionResponse> GetCollectionRevisionAsync(string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             using (var response = await _transport.GetAsync(
                 _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/revision",
-                null,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
                 token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
@@ -286,18 +300,20 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="collectionName"></param>
         /// <param name="body"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PutCollectionPropertyResponse> PutCollectionPropertyAsync(
             string collectionName,
             PutCollectionPropertyBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
             using (var response = await _transport.PutAsync(
                 _collectionApiPath + "/" + collectionName + "/properties", 
                 content,
-                null,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
                 token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
@@ -314,14 +330,16 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET/_api/collection/{collection-name}/figures
         /// </summary>
         /// <param name="collectionName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetCollectionFiguresResponse> GetCollectionFiguresAsync(string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             using (var response = await _transport.GetAsync(
                 _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/figures",
-                null,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
                 token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
@@ -340,11 +358,13 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
         /// <param name="query">Query options.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetChecksumResponse> GetChecksumAsync(
             string collectionName,
             GetChecksumQuery query = null,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(collectionName))
@@ -356,7 +376,7 @@ namespace ArangoDBNetStandard.CollectionApi
             {
                 uriString += "?" + query.ToQueryString();
             }
-            using (var response = await _transport.GetAsync(uriString, null, token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uriString, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -376,9 +396,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// PUT /_api/collection/{collection-name}/loadIndexesIntoMemory
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PutLoadIndexesIntoMemoryResponse> PutLoadIndexesIntoMemoryAsync(string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(collectionName))
@@ -386,7 +408,7 @@ namespace ArangoDBNetStandard.CollectionApi
                 throw new ArgumentException($"{nameof(collectionName)} is required", nameof(collectionName));
             }
             string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/loadIndexesIntoMemory";
-            using (var response = await _transport.PutAsync(uriString, new byte[] { }, null, token).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uriString, new byte[] { }, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -402,9 +424,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// PUT /_api/collection/{collection-name}/recalculateCount
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PutRecalculateCountResponse> PutRecalculateCountAsync(string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(collectionName))
@@ -412,7 +436,7 @@ namespace ArangoDBNetStandard.CollectionApi
                 throw new ArgumentException($"{nameof(collectionName)} is required", nameof(collectionName));
             }
             string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/recalculateCount";
-            using (var response = await _transport.PutAsync(uriString, new byte[] { },null,token).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uriString, new byte[] { }, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -433,11 +457,13 @@ namespace ArangoDBNetStandard.CollectionApi
         /// pairs with at least the collection’s shard 
         /// key attributes set to some values.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PutDocumentShardResponse> PutDocumentShardAsync(
             string collectionName, 
             Dictionary<string, object> body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(collectionName))
@@ -450,7 +476,7 @@ namespace ArangoDBNetStandard.CollectionApi
             }
             string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/responsibleShard";
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _transport.PutAsync(uriString, content, null, token).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uriString, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -467,9 +493,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET /_api/collection/{collection-name}/shards
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetCollectionShardsResponse> GetCollectionShardsAsync(string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(collectionName))
@@ -477,7 +505,7 @@ namespace ArangoDBNetStandard.CollectionApi
                 throw new ArgumentException($"{nameof(collectionName)} is required", nameof(collectionName));
             }
             string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/shards";
-            using (var response = await _transport.GetAsync(uriString, null, token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uriString, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -497,9 +525,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET /_api/collection/{collection-name}/shards?details=true
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetCollectionShardsDetailedResponse> GetCollectionShardsWithDetailsAsync(string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(collectionName))
@@ -507,7 +537,7 @@ namespace ArangoDBNetStandard.CollectionApi
                 throw new ArgumentException($"{nameof(collectionName)} is required", nameof(collectionName));
             }
             string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/shards?details=true";
-            using (var response = await _transport.GetAsync(uriString, null, token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uriString, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -525,9 +555,10 @@ namespace ArangoDBNetStandard.CollectionApi
         /// PUT /_api/collection/{collection-name}/compact
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<PutCompactCollectionDataResponse> PutCompactCollectionDataAsync(string collectionName,
+        public virtual async Task<PutCompactCollectionDataResponse> PutCompactCollectionDataAsync(string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(collectionName))
@@ -535,7 +566,7 @@ namespace ArangoDBNetStandard.CollectionApi
                 throw new ArgumentException($"{nameof(collectionName)} is required", nameof(collectionName));
             }
             string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/compact";
-            using (var response = await _transport.PutAsync(uriString, new byte[] { },null,token).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uriString, new byte[] { }, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/CollectionApi/ICollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/ICollectionApiClient.cs
@@ -16,20 +16,22 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="body">Attributes of the new collection</param>
         /// <param name="options">Query string options for the task.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PostCollectionResponse> PostCollectionAsync(
            PostCollectionBody body,
-           PostCollectionQuery options = null,
+           PostCollectionQuery options = null, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Deletes a collection.
         /// </summary>
         /// <param name="collectionName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<DeleteCollectionResponse> DeleteCollectionAsync(string collectionName,
+        Task<DeleteCollectionResponse> DeleteCollectionAsync(string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -61,9 +63,10 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET/_api/collection
         /// </summary>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetCollectionsResponse> GetCollectionsAsync(GetCollectionsQuery query = null,
+        Task<GetCollectionsResponse> GetCollectionsAsync(GetCollectionsQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -71,9 +74,10 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET/_api/collection/{collection-name}
         /// </summary>
         /// <param name="collectionName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetCollectionResponse> GetCollectionAsync(string collectionName,
+        Task<GetCollectionResponse> GetCollectionAsync(string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -81,9 +85,10 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET /_api/collection/{collection-name}/properties
         /// </summary>
         /// <param name="collectionName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetCollectionPropertiesResponse> GetCollectionPropertiesAsync(string collectionName,
+        Task<GetCollectionPropertiesResponse> GetCollectionPropertiesAsync(string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -92,11 +97,12 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="collectionName"></param>
         /// <param name="body"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<RenameCollectionResponse> RenameCollectionAsync(
             string collectionName,
-            RenameCollectionBody body,
+            RenameCollectionBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -104,9 +110,10 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET /_api/collection/{collection-name}/revision
         /// </summary>
         /// <param name="collectionName">Name of the collection</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetCollectionRevisionResponse> GetCollectionRevisionAsync(string collectionName,
+        Task<GetCollectionRevisionResponse> GetCollectionRevisionAsync(string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -115,11 +122,12 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="collectionName"></param>
         /// <param name="body"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PutCollectionPropertyResponse> PutCollectionPropertyAsync(
            string collectionName,
-           PutCollectionPropertyBody body,
+           PutCollectionPropertyBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -127,9 +135,10 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET/_api/collection/{collection-name}/figures
         /// </summary>
         /// <param name="collectionName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetCollectionFiguresResponse> GetCollectionFiguresAsync(string collectionName,
+        Task<GetCollectionFiguresResponse> GetCollectionFiguresAsync(string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -138,10 +147,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
         /// <param name="query">Query options.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetChecksumResponse> GetChecksumAsync(string collectionName,
-            GetChecksumQuery query = null,
+            GetChecksumQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -153,10 +163,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// PUT /_api/collection/{collection-name}/loadIndexesIntoMemory
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PutLoadIndexesIntoMemoryResponse> PutLoadIndexesIntoMemoryAsync(
-           string collectionName,
+           string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -164,10 +175,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// PUT /_api/collection/{collection-name}/recalculateCount
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PutRecalculateCountResponse> PutRecalculateCountAsync(
-           string collectionName,
+           string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -180,11 +192,12 @@ namespace ArangoDBNetStandard.CollectionApi
         /// pairs with at least the collection’s shard 
         /// key attributes set to some values.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PutDocumentShardResponse> PutDocumentShardAsync(
            string collectionName,
-           Dictionary<string, object> body,
+           Dictionary<string, object> body, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -193,10 +206,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET /_api/collection/{collection-name}/shards
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetCollectionShardsResponse> GetCollectionShardsAsync(
-           string collectionName,
+           string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -208,10 +222,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// GET /_api/collection/{collection-name}/shards?details=true
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetCollectionShardsDetailedResponse> GetCollectionShardsWithDetailsAsync(
-           string collectionName,
+           string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -221,10 +236,11 @@ namespace ArangoDBNetStandard.CollectionApi
         /// PUT /_api/collection/{collection-name}/compact
         /// </summary>
         /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PutCompactCollectionDataResponse> PutCompactCollectionDataAsync(
-           string collectionName,
+           string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -152,7 +152,7 @@ namespace ArangoDBNetStandard.CursorApi
         {
             using (var response = await _client.DeleteAsync(
                 _cursorApiPath + "/" + WebUtility.UrlEncode(cursorId),
-                webHeaderCollection: headers?.ToWebHeaderCollection(),,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
                 token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
@@ -178,7 +178,7 @@ namespace ArangoDBNetStandard.CursorApi
             CancellationToken token = default)
         {
             string uri = _cursorApiPath + "/" + WebUtility.UrlEncode(cursorId);
-            using (var response = await _client.PutAsync(uri, new byte[0], webHeaderCollection: headers?.ToWebHeaderCollection(),, token).ConfigureAwait(false))
+            using (var response = await _client.PutAsync(uri, new byte[0], webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -69,7 +70,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="cache"></param>
         /// <param name="memoryLimit"></param>
         /// <param name="ttl"></param>
-        /// <param name="transactionId">Optional. The stream transaction Id.</param>      
+        /// <param name="transactionId">Optional. The stream transaction Id.</param>  
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(
@@ -143,14 +144,15 @@ namespace ArangoDBNetStandard.CursorApi
         /// DELETE /_api/cursor/{cursor-identifier}
         /// </summary>
         /// <param name="cursorId">The id of the cursor to delete.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<DeleteCursorResponse> DeleteCursorAsync(string cursorId,
+        public virtual async Task<DeleteCursorResponse> DeleteCursorAsync(string cursorId, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             using (var response = await _client.DeleteAsync(
                 _cursorApiPath + "/" + WebUtility.UrlEncode(cursorId),
-                null,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),,
                 token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
@@ -168,14 +170,15 @@ namespace ArangoDBNetStandard.CursorApi
         /// </summary>
         /// <typeparam name="T">Result type to deserialize to</typeparam>
         /// <param name="cursorId">ID of the existing query cursor.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         [Obsolete("Use PostAdvanceCursorAsync.")]
-        public virtual async Task<PutCursorResponse<T>> PutCursorAsync<T>(string cursorId,
+        public virtual async Task<PutCursorResponse<T>> PutCursorAsync<T>(string cursorId, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _cursorApiPath + "/" + WebUtility.UrlEncode(cursorId);
-            using (var response = await _client.PutAsync(uri, new byte[0], null, token).ConfigureAwait(false))
+            using (var response = await _client.PutAsync(uri, new byte[0], webHeaderCollection: headers?.ToWebHeaderCollection(),, token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -189,16 +192,18 @@ namespace ArangoDBNetStandard.CursorApi
 
         /// <summary>
         /// Advances an existing query cursor and gets the next set of results.
-        /// Replaces <see cref="PutCursorAsync{T}(string, CancellationToken)"/>
+        /// Replaces <see cref="PutCursorAsync{T}(string,ApiHeaderProperties, CancellationToken)"/>
         /// </summary>
         /// <param name="cursorIdentifier">The name / identifier of the existing cursor.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<CursorResponse<T>> PostAdvanceCursorAsync<T>(string cursorIdentifier, CancellationToken token = default)
+        public virtual async Task<CursorResponse<T>> PostAdvanceCursorAsync<T>(string cursorIdentifier, ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             using (var response = await _client.PostAsync(
                 requestUri: _cursorApiPath + $"/{WebUtility.UrlEncode(cursorIdentifier)}",
                 content: new byte[] { },
+                webHeaderCollection:headers?.ToWebHeaderCollection(),
                 token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/CursorApi/ICursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/ICursorApiClient.cs
@@ -22,7 +22,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="cache"></param>
         /// <param name="memoryLimit"></param>
         /// <param name="ttl"></param>
-        /// <param name="transactionId">Optional. The stream transaction Id.</param>      
+        /// <param name="transactionId">Optional. The stream transaction Id.</param>     
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<CursorResponse<T>> PostCursorAsync<T>(
@@ -55,13 +55,14 @@ namespace ArangoDBNetStandard.CursorApi
 
         /// <summary>
         /// Advances an existing query cursor and gets the next set of results.
-        /// Replaces <see cref="PutCursorAsync{T}(string, CancellationToken)"/>
+        /// Replaces <see cref="PutCursorAsync{T}(string, ApiHeaderProperties, CancellationToken)"/>
         /// </summary>
         /// <param name="cursorIdentifier">The name / identifier of the existing cursor.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<CursorResponse<T>> PostAdvanceCursorAsync<T>(
-            string cursorIdentifier,
+            string cursorIdentifier, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -69,9 +70,10 @@ namespace ArangoDBNetStandard.CursorApi
         /// DELETE /_api/cursor/{cursor-identifier}
         /// </summary>
         /// <param name="cursorId">The id of the cursor to delete.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<DeleteCursorResponse> DeleteCursorAsync(string cursorId,
+        Task<DeleteCursorResponse> DeleteCursorAsync(string cursorId, ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -79,9 +81,10 @@ namespace ArangoDBNetStandard.CursorApi
         /// </summary>
         /// <typeparam name="T">Result type to deserialize to</typeparam>
         /// <param name="cursorId">ID of the existing query cursor.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<PutCursorResponse<T>> PutCursorAsync<T>(string cursorId,
+        Task<PutCursorResponse<T>> PutCursorAsync<T>(string cursorId, ApiHeaderProperties headers = null,
             CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/CustomHttpHeaders.cs
+++ b/arangodb-net-standard/CustomHttpHeaders.cs
@@ -18,5 +18,9 @@
         /// The header string used for Driver Info Header
         /// </summary>    
         public const string DriverInfoHeader = "x-arango-driver";
+        /// <summary>
+        /// The header string used for <see cref="ApiHeaderProperties.MaxQueueTimeLimit"/> 
+        /// </summary>    
+        public const string MaxQueueTimeLimitHeader = "x-arango-max-queue-time-seconds";
     }
 }

--- a/arangodb-net-standard/DatabaseApi/DatabaseApiClient.cs
+++ b/arangodb-net-standard/DatabaseApi/DatabaseApiClient.cs
@@ -51,12 +51,13 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// (Only possible from within the _system database)
         /// </summary>
         /// <param name="request">The parameters required by this endpoint.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<PostDatabaseResponse> PostDatabaseAsync(PostDatabaseBody request, CancellationToken token = default)
+        public virtual async Task<PostDatabaseResponse> PostDatabaseAsync(PostDatabaseBody request, ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             var content = await GetContentAsync(request, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PostAsync(_databaseApiPath, content, null, token).ConfigureAwait(false))
+            using (var response = await _client.PostAsync(_databaseApiPath, content, webHeaderCollection: headers?.ToWebHeaderCollection(), token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -73,11 +74,15 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// DELETE /_api/database/{database-name}
         /// </summary>
         /// <param name="databaseName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<DeleteDatabaseResponse> DeleteDatabaseAsync(string databaseName, CancellationToken token = default)
+        public virtual async Task<DeleteDatabaseResponse> DeleteDatabaseAsync(string databaseName, ApiHeaderProperties headers = null, CancellationToken token = default)
         {
-            using (var response = await _client.DeleteAsync(_databaseApiPath + "/" + WebUtility.UrlEncode(databaseName), null, token).ConfigureAwait(false))
+            using (var response = await _client.DeleteAsync(
+                _databaseApiPath + "/" + WebUtility.UrlEncode(databaseName),
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -92,15 +97,19 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// Retrieves the list of all existing databases.
         /// (Only possible from within the _system database)
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// You should use <see cref="GetUserDatabasesAsync"/> to fetch the list of the databases
         /// available for the current user.
         /// </remarks>
         /// <returns></returns>
-        public virtual async Task<GetDatabasesResponse> GetDatabasesAsync(CancellationToken token = default)
+        public virtual async Task<GetDatabasesResponse> GetDatabasesAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
-            using (var response = await _client.GetAsync(_databaseApiPath, null, token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(
+                _databaseApiPath,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -114,11 +123,15 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// <summary>
         /// Retrieves the list of all databases the current user can access.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<GetDatabasesResponse> GetUserDatabasesAsync(CancellationToken token = default)
+        public virtual async Task<GetDatabasesResponse> GetUserDatabasesAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
-            using (var response = await _client.GetAsync(_databaseApiPath + "/user", null, token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(
+                _databaseApiPath + "/user",
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -132,11 +145,15 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// <summary>
         /// Retrieves information about the current database.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<GetCurrentDatabaseInfoResponse> GetCurrentDatabaseInfoAsync(CancellationToken token = default)
+        public virtual async Task<GetCurrentDatabaseInfoResponse> GetCurrentDatabaseInfoAsync(ApiHeaderProperties headers = null, CancellationToken token = default)
         {
-            using (var response = await _client.GetAsync(_databaseApiPath + "/current",null,token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(
+                _databaseApiPath + "/current",
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/DatabaseApi/IDatabaseApiClient.cs
+++ b/arangodb-net-standard/DatabaseApi/IDatabaseApiClient.cs
@@ -14,9 +14,10 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// (Only possible from within the _system database)
         /// </summary>
         /// <param name="request">The parameters required by this endpoint.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<PostDatabaseResponse> PostDatabaseAsync(PostDatabaseBody request, CancellationToken token = default);
+        Task<PostDatabaseResponse> PostDatabaseAsync(PostDatabaseBody request, ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Delete a database. Dropping a database is only possible from within the _system database.
@@ -24,34 +25,38 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// DELETE /_api/database/{database-name}
         /// </summary>
         /// <param name="databaseName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<DeleteDatabaseResponse> DeleteDatabaseAsync(string databaseName, CancellationToken token = default);
+        Task<DeleteDatabaseResponse> DeleteDatabaseAsync(string databaseName, ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Retrieves the list of all existing databases.
         /// (Only possible from within the _system database)
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// You should use <see cref="GetUserDatabasesAsync"/> to fetch the list of the databases
         /// available for the current user.
         /// </remarks>
         /// <returns></returns>
-        Task<GetDatabasesResponse> GetDatabasesAsync(CancellationToken token = default);
+        Task<GetDatabasesResponse> GetDatabasesAsync(ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Retrieves the list of all databases the current user can access.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetDatabasesResponse> GetUserDatabasesAsync(CancellationToken token = default);
+        Task<GetDatabasesResponse> GetUserDatabasesAsync(ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Retrieves information about the current database.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetCurrentDatabaseInfoResponse> GetCurrentDatabaseInfoAsync(CancellationToken token = default);
+        Task<GetCurrentDatabaseInfoResponse> GetCurrentDatabaseInfoAsync(ApiHeaderProperties headers = null, CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/DocumentApi/Models/DocumentHeaderProperties.cs
+++ b/arangodb-net-standard/DocumentApi/Models/DocumentHeaderProperties.cs
@@ -2,7 +2,7 @@
 
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
-    public class DocumentHeaderProperties:ApiHeaderProperties
+    public class DocumentHeaderProperties: ApiHeaderProperties
     {
         public string IfMatch { get; set; }
 

--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -57,11 +57,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// </remarks>
         /// <param name="postGraphBody">The information of the graph to create. Must be an instance of <see cref="PostSatelliteGraphOptions"/> or <see cref="PostNonSatelliteGraphOptions"/>.</param>
         /// <param name="query">Optional query parameters of the request.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostGraphResponse> PostGraphAsync(
             PostGraphBody postGraphBody,
-            PostGraphQuery query = null, CancellationToken token = default)
+            PostGraphQuery query = null,
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
             string uri = _graphApiPath;
 
@@ -72,7 +75,9 @@ namespace ArangoDBNetStandard.GraphApi
 
             var content = await GetContentAsync(postGraphBody, new ApiClientSerializationOptions(true, true));
 
-            using (var response = await _transport.PostAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -87,15 +92,20 @@ namespace ArangoDBNetStandard.GraphApi
         /// Lists all graphs stored in this database.
         /// GET /_api/gharial
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Note: The <see cref="GraphResult.Name"/> property is null for <see cref="GraphApiClient.GetGraphsAsync"/>
         /// in ArangoDB 4.5.2 and below, in which case you can use <see cref="GraphResult._key"/> instead.
         /// </remarks>
         /// <returns></returns>
-        public virtual async Task<GetGraphsResponse> GetGraphsAsync( CancellationToken token = default)
+        public virtual async Task<GetGraphsResponse> GetGraphsAsync(
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
-            using (var response = await _transport.GetAsync(_graphApiPath, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(_graphApiPath,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -114,18 +124,23 @@ namespace ArangoDBNetStandard.GraphApi
         /// </summary>
         /// <param name="graphName"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteGraphResponse> DeleteGraphAsync(
             string graphName,
-            DeleteGraphQuery query = null, CancellationToken token = default)
+            DeleteGraphQuery query = null,
+            GraphHeaderProperties headers = null,
+             CancellationToken token = default)
         {
             string uriString = _graphApiPath + "/" + WebUtility.UrlEncode(graphName);
             if (query != null)
             {
                 uriString += "?" + query.ToQueryString();
             }
-            using (var response = await _transport.DeleteAsync(uriString, token: token).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uriString,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                 token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -142,11 +157,17 @@ namespace ArangoDBNetStandard.GraphApi
         /// GET /_api/gharial/{graph}
         /// </summary>
         /// <param name="graphName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<GetGraphResponse> GetGraphAsync(string graphName, CancellationToken token = default)
+        public virtual async Task<GetGraphResponse> GetGraphAsync(string graphName,
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
-            using (var response = await _transport.GetAsync(_graphApiPath + "/" + WebUtility.UrlEncode(graphName), token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(
+                _graphApiPath + "/" + WebUtility.UrlEncode(graphName),
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -162,11 +183,17 @@ namespace ArangoDBNetStandard.GraphApi
         /// GET /_api/gharial/{graph}/vertex
         /// </summary>
         /// <param name="graphName">The name of the graph.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<GetVertexCollectionsResponse> GetVertexCollectionsAsync(string graphName, CancellationToken token = default)
+        public virtual async Task<GetVertexCollectionsResponse> GetVertexCollectionsAsync(string graphName,
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
-            using (var response = await _transport.GetAsync(_graphApiPath + '/' + WebUtility.UrlEncode(graphName) + "/vertex", token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(
+                _graphApiPath + '/' + WebUtility.UrlEncode(graphName) + "/vertex",
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                 token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -182,11 +209,17 @@ namespace ArangoDBNetStandard.GraphApi
         /// GET /_api/gharial/{graph}/edge
         /// </summary>
         /// <param name="graphName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<GetEdgeCollectionsResponse> GetEdgeCollectionsAsync(string graphName, CancellationToken token = default)
+        public virtual async Task<GetEdgeCollectionsResponse> GetEdgeCollectionsAsync(string graphName,
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
-            using (var response = await _transport.GetAsync(_graphApiPath + "/" + WebUtility.UrlEncode(graphName) + "/edge",  token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(
+                _graphApiPath + "/" + WebUtility.UrlEncode(graphName) + "/edge",
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                 token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -209,17 +242,22 @@ namespace ArangoDBNetStandard.GraphApi
         /// </summary>
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="body">The information of the edge definition.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostEdgeDefinitionResponse> PostEdgeDefinitionAsync(
             string graphName,
-            PostEdgeDefinitionBody body, CancellationToken token = default)
+            PostEdgeDefinitionBody body,
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true));
 
             string uri = _graphApiPath + "/" + WebUtility.UrlEncode(graphName) + "/edge";
 
-            using (var response = await _transport.PostAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -237,17 +275,22 @@ namespace ArangoDBNetStandard.GraphApi
         /// </summary>
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="body">The information of the vertex collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostVertexCollectionResponse> PostVertexCollectionAsync(
             string graphName,
-            PostVertexCollectionBody body, CancellationToken token = default)
+            PostVertexCollectionBody body,
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
             string uri = _graphApiPath + '/' + WebUtility.UrlEncode(graphName) + "/vertex";
 
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true));
 
-            using (var response = await _transport.PostAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                 token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -288,7 +331,9 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
             var content = await GetContentAsync(vertex, serializationOptions).ConfigureAwait(false);
-            using (var response = await _transport.PostAsync(uri, content,headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, content,
+                headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -308,12 +353,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName"></param>
         /// <param name="collectionName"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteEdgeDefinitionResponse> DeleteEdgeDefinitionAsync(
             string graphName,
             string collectionName,
-            DeleteEdgeDefinitionQuery query = null, CancellationToken token = default)
+            DeleteEdgeDefinitionQuery query = null,
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
             string uri = _graphApiPath + "/" + WebUtility.UrlEncode(graphName) +
                 "/edge/" + WebUtility.UrlEncode(collectionName);
@@ -321,7 +369,9 @@ namespace ArangoDBNetStandard.GraphApi
             {
                 uri += "?" + query.ToQueryString();
             }
-            using (var response = await _transport.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                 token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -342,12 +392,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName"></param>
         /// <param name="collectionName"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteVertexCollectionResponse> DeleteVertexCollectionAsync(
             string graphName,
             string collectionName,
-            DeleteVertexCollectionQuery query = null, CancellationToken token = default)
+            DeleteVertexCollectionQuery query = null,
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
             string uri = _graphApiPath + "/" + WebUtility.UrlEncode(graphName) +
                 "/vertex/" + WebUtility.UrlEncode(collectionName);
@@ -355,7 +408,9 @@ namespace ArangoDBNetStandard.GraphApi
             {
                 uri += "?" + query.ToQueryString();
             }
-            using (var response = await _transport.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                 token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -568,7 +623,9 @@ namespace ArangoDBNetStandard.GraphApi
             return GetVertexAsync<T>(
                 graphName,
                 WebUtility.UrlEncode(collectionName) + "/" + vertexKey,
-                query, token: token);
+                query,
+                headers, 
+                token: token);
         }
 
         /// <summary>
@@ -849,13 +906,16 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName"></param>
         /// <param name="body"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PutEdgeDefinitionResponse> PutEdgeDefinitionAsync(
             string graphName,
             string collectionName,
             PutEdgeDefinitionBody body,
-            PutEdgeDefinitionQuery query = null, CancellationToken token = default)
+            PutEdgeDefinitionQuery query = null,
+            GraphHeaderProperties headers = null,
+            CancellationToken token = default)
         {
             string uriString = _graphApiPath + "/" +
                 WebUtility.UrlEncode(graphName) + "/edge/" +
@@ -866,7 +926,9 @@ namespace ArangoDBNetStandard.GraphApi
                 uriString += "?" + query.ToQueryString();
             }
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _transport.PutAsync(uriString, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uriString, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                 token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -1036,6 +1098,5 @@ namespace ArangoDBNetStandard.GraphApi
                 throw await GetApiErrorExceptionAsync(response).ConfigureAwait(false);
             }
         }
-
     }
 }

--- a/arangodb-net-standard/GraphApi/IGraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/IGraphApiClient.cs
@@ -16,23 +16,29 @@ namespace ArangoDBNetStandard.GraphApi
         /// </summary>
         /// <param name="postGraphBody">The information of the graph to create.</param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PostGraphResponse> PostGraphAsync(
           PostGraphBody postGraphBody,
-          PostGraphQuery query = null, CancellationToken token = default);
+          PostGraphQuery query = null,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Lists all graphs stored in this database.
         /// GET /_api/gharial
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// Note: The <see cref="GraphResult.Name"/> property is null for <see cref="GraphApiClient.GetGraphsAsync"/>
         /// in ArangoDB 4.5.2 and below, in which case you can use <see cref="GraphResult._key"/> instead.
         /// </remarks>
         /// <returns></returns>
-        Task<GetGraphsResponse> GetGraphsAsync(CancellationToken token = default);
+        Task<GetGraphsResponse> GetGraphsAsync(
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Deletes an existing graph object by name.
@@ -42,11 +48,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// </summary>
         /// <param name="graphName"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<DeleteGraphResponse> DeleteGraphAsync(
           string graphName,
-          DeleteGraphQuery query = null, CancellationToken token = default);
+          DeleteGraphQuery query = null,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Selects information for a given graph.
@@ -54,27 +63,36 @@ namespace ArangoDBNetStandard.GraphApi
         /// GET /_api/gharial/{graph}
         /// </summary>
         /// <param name="graphName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetGraphResponse> GetGraphAsync(string graphName, CancellationToken token = default);
+        Task<GetGraphResponse> GetGraphAsync(string graphName,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Lists all vertex collections within the given graph.
         /// GET /_api/gharial/{graph}/vertex
         /// </summary>
         /// <param name="graphName">The name of the graph.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetVertexCollectionsResponse> GetVertexCollectionsAsync(string graphName, CancellationToken token = default);
+        Task<GetVertexCollectionsResponse> GetVertexCollectionsAsync(string graphName,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Lists all edge collections within this graph.
         /// GET /_api/gharial/{graph}/edge
         /// </summary>
         /// <param name="graphName"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<GetEdgeCollectionsResponse> GetEdgeCollectionsAsync(string graphName, CancellationToken token = default);
+        Task<GetEdgeCollectionsResponse> GetEdgeCollectionsAsync(string graphName,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Adds an additional edge definition to the graph.
@@ -88,11 +106,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// </summary>
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="body">The information of the edge definition.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PostEdgeDefinitionResponse> PostEdgeDefinitionAsync(
           string graphName,
-          PostEdgeDefinitionBody body, CancellationToken token = default);
+          PostEdgeDefinitionBody body,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Adds a vertex collection to the set of orphan collections of the graph.
@@ -101,11 +122,14 @@ namespace ArangoDBNetStandard.GraphApi
         /// </summary>
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="body">The information of the vertex collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PostVertexCollectionResponse> PostVertexCollectionAsync(
           string graphName,
-          PostVertexCollectionBody body, CancellationToken token = default);
+          PostVertexCollectionBody body,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Adds a vertex to the given collection.
@@ -138,12 +162,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName"></param>
         /// <param name="collectionName"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<DeleteEdgeDefinitionResponse> DeleteEdgeDefinitionAsync(
           string graphName,
           string collectionName,
-          DeleteEdgeDefinitionQuery query = null, CancellationToken token = default);
+          DeleteEdgeDefinitionQuery query = null,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Removes a vertex collection from the graph and optionally deletes the collection,
@@ -155,12 +182,15 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName"></param>
         /// <param name="collectionName"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<DeleteVertexCollectionResponse> DeleteVertexCollectionAsync(
           string graphName,
           string collectionName,
-          DeleteVertexCollectionQuery query = null, CancellationToken token = default);
+          DeleteVertexCollectionQuery query = null,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Creates an edge in an existing graph.
@@ -430,13 +460,16 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName"></param>
         /// <param name="body"></param>
         /// <param name="query"></param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PutEdgeDefinitionResponse> PutEdgeDefinitionAsync(
           string graphName,
           string collectionName,
           PutEdgeDefinitionBody body,
-          PutEdgeDefinitionQuery query = null, CancellationToken token = default);
+          PutEdgeDefinitionQuery query = null,
+          GraphHeaderProperties headers = null,
+          CancellationToken token = default);
 
         /// <summary>
         /// Updates the data of the specific edge in the collection.
@@ -530,6 +563,7 @@ namespace ArangoDBNetStandard.GraphApi
           T vertex,
           PutVertexQuery query = null,
           ApiClientSerializationOptions serializationOptions = null,
-          GraphHeaderProperties headers = null, CancellationToken token = default);
+          GraphHeaderProperties headers = null, 
+          CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/IndexApi/IIndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IIndexApiClient.cs
@@ -15,42 +15,50 @@ namespace ArangoDBNetStandard.IndexApi
         /// Fetches data about the specified index.
         /// </summary>
         /// <param name="indexId">The index identifier.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetIndexResponse> GetIndexAsync(string indexId,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Delete an index permanently.
         /// </summary>
         /// <param name="indexId">The index identifier.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<DeleteIndexResponse> DeleteIndexAsync(string indexId,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Fetch the list of indexes for a collection.
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetAllCollectionIndexesResponse> GetAllCollectionIndexesAsync(GetAllCollectionIndexesQuery query,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Generic method to create an index.
         /// It is highly recommended that you use a specialized method like
-        /// <see cref="PostGeoSpatialIndexAsync(PostIndexQuery, PostGeoSpatialIndexBody, CancellationToken)"/>
+        /// <see cref="PostGeoSpatialIndexAsync(PostIndexQuery, PostGeoSpatialIndexBody,ApiHeaderProperties, CancellationToken)"/>
         /// to create indexes. Use this method to create indexes that do not
         /// have a specialized method available.
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>       
         Task<IndexResponseBase> PostIndexAsync(PostIndexQuery query,
             PostIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -74,10 +82,12 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<IndexResponseBase> PostGeoSpatialIndexAsync(PostIndexQuery query,
             PostGeoSpatialIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -101,10 +111,12 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<IndexResponseBase> PostMultiDimensionalIndexAsync(PostIndexQuery query,
             PostMultiDimensionalIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -112,10 +124,12 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<IndexResponseBase> PostPersistentIndexAsync(PostIndexQuery query,
             PostPersistentIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -139,10 +153,12 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<IndexResponseBase> PostTTLIndexAsync(PostIndexQuery query,
             PostTTLIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -150,10 +166,12 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<InvertedIndexResponse> PostInvertedIndexAsync(PostIndexQuery query,
             PostInvertedIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/IndexApi/IndexApiClient.cs
+++ b/arangodb-net-standard/IndexApi/IndexApiClient.cs
@@ -52,13 +52,17 @@ namespace ArangoDBNetStandard.IndexApi
         /// Fetches data about the specified index.
         /// </summary>
         /// <param name="indexId">The identifier of the index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetIndexResponse> GetIndexAsync(string indexId,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _indexApiPath + '/' + indexId;
-            using (var response = await _client.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -73,13 +77,17 @@ namespace ArangoDBNetStandard.IndexApi
         /// Delete an index permanently.
         /// </summary>
         /// <param name="indexId">The identifier of the index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteIndexResponse> DeleteIndexAsync(string indexId,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _indexApiPath + "/" + indexId;
-            using (var response = await _client.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.DeleteAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -95,10 +103,12 @@ namespace ArangoDBNetStandard.IndexApi
         /// Fetch the list of indexes for a collection.
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentException">Required parameters not provided or invalid.</exception>
         public virtual async Task<GetAllCollectionIndexesResponse> GetAllCollectionIndexesAsync(GetAllCollectionIndexesQuery query,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _indexApiPath;
@@ -114,7 +124,9 @@ namespace ArangoDBNetStandard.IndexApi
             }
 
             uri += '?' + query.ToQueryString();
-            using (var response = await _client.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -128,16 +140,18 @@ namespace ArangoDBNetStandard.IndexApi
         /// <summary>
         /// Generic method to create an index.
         /// It is highly recommended that you use a specialized method like
-        /// <see cref="PostGeoSpatialIndexAsync(PostIndexQuery, PostGeoSpatialIndexBody, CancellationToken)"/>
+        /// <see cref="PostGeoSpatialIndexAsync(PostIndexQuery, PostGeoSpatialIndexBody, ApiHeaderProperties, CancellationToken)"/>
         /// to create indexes. Use this method to create indexes that do not
         /// have a specialized method available.
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>  
         public virtual async Task<IndexResponseBase> PostIndexAsync(PostIndexQuery query, 
             PostIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _indexApiPath;
@@ -159,7 +173,9 @@ namespace ArangoDBNetStandard.IndexApi
 
             uri += '?' + query.ToQueryString();
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PostAsync(uri, content,token:token).ConfigureAwait(false))
+            using (var response = await _client.PostAsync(uri, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token:token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -186,7 +202,7 @@ namespace ArangoDBNetStandard.IndexApi
             PostFulltextIndexBody body,
             CancellationToken token = default)
         {
-            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+            return await PostIndexAsync(query: query, body: body, token: token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -194,13 +210,15 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<IndexResponseBase> PostGeoSpatialIndexAsync(PostIndexQuery query,
             PostGeoSpatialIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
-            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+            return await PostIndexAsync(query, body, headers, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,7 +237,7 @@ namespace ArangoDBNetStandard.IndexApi
             PostHashIndexBody body,
             CancellationToken token = default)
         {
-            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+            return await PostIndexAsync(query: query, body: body, token: token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -227,13 +245,15 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<IndexResponseBase> PostMultiDimensionalIndexAsync(PostIndexQuery query,
             PostMultiDimensionalIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
-            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+            return await PostIndexAsync(query, body, headers, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -241,13 +261,15 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<IndexResponseBase> PostPersistentIndexAsync(PostIndexQuery query,
             PostPersistentIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
-            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+            return await PostIndexAsync(query, body, headers, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -266,7 +288,7 @@ namespace ArangoDBNetStandard.IndexApi
             PostSkiplistIndexBody body,
             CancellationToken token = default)
         {
-            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+            return await PostIndexAsync(query: query, body: body, token: token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -274,13 +296,15 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<IndexResponseBase> PostTTLIndexAsync(PostIndexQuery query,
             PostTTLIndexBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
-            return await PostIndexAsync(query, body, token).ConfigureAwait(false);
+            return await PostIndexAsync(query, body, headers, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -288,9 +312,13 @@ namespace ArangoDBNetStandard.IndexApi
         /// </summary>
         /// <param name="query">Query parameters for the request.</param>
         /// <param name="body">The properties of the new index.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<InvertedIndexResponse> PostInvertedIndexAsync(PostIndexQuery query, PostInvertedIndexBody body, CancellationToken token = default)
+        public virtual async Task<InvertedIndexResponse> PostInvertedIndexAsync(PostIndexQuery query, 
+            PostInvertedIndexBody body,
+            ApiHeaderProperties headers = null,
+            CancellationToken token = default)
         {
             string uri = _indexApiPath;
 
@@ -311,7 +339,9 @@ namespace ArangoDBNetStandard.IndexApi
 
             uri += '?' + query.ToQueryString();
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PostAsync(uri, content: content,  token: token).ConfigureAwait(false))
+            using (var response = await _client.PostAsync(uri, content: content, 
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/PregelApi/IPregelApiClient.cs
+++ b/arangodb-net-standard/PregelApi/IPregelApiClient.cs
@@ -26,10 +26,12 @@ namespace ArangoDBNetStandard.PregelApi
         /// vary for each algorithm
         /// </remarks>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns>The ID of the newly started job.</returns>
         Task<string> PostStartJobAsync(
             PostStartJobBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -37,22 +39,26 @@ namespace ArangoDBNetStandard.PregelApi
         /// GET /_api/control_pregel/{id}
         /// </summary>
         /// <param name="jobId">The ID of the job.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PregelJobStatus> GetJobStatusAsync(
             string jobId,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
         /// Get the overview of currently running Pregel jobs.
         /// GET /_api/control_pregel
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns>
         /// Returns a list of currently running and recently
         /// finished Pregel jobs without retrieving their results. 
         /// </returns>
         Task<List<PregelJobStatus>> GetAllRunningJobsAsync(
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -67,10 +73,12 @@ namespace ArangoDBNetStandard.PregelApi
         /// For more information see https://www.arangodb.com/docs/stable/http/pregel.html#cancel-pregel-job-execution
         /// </remarks>
         /// <param name="jobId">The ID of the job.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<string> DeleteJobAsync(
             string jobId,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/PregelApi/PregelApiClient.cs
+++ b/arangodb-net-standard/PregelApi/PregelApiClient.cs
@@ -63,13 +63,18 @@ namespace ArangoDBNetStandard.PregelApi
         /// vary for each algorithm
         /// </remarks>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns>The ID of the newly started job.</returns>
-        public virtual async Task<string> PostStartJobAsync(PostStartJobBody body, CancellationToken token = default)
+        public virtual async Task<string> PostStartJobAsync(PostStartJobBody body,
+            ApiHeaderProperties headers = null,
+            CancellationToken token = default)
         {
             string uri = _apiPath;
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true));
-            using (var response = await _transport.PostAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, content, 
+                webHeaderCollection:headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -85,16 +90,20 @@ namespace ArangoDBNetStandard.PregelApi
         /// GET /_api/control_pregel/{id}
         /// </summary>
         /// <param name="jobId">The ID of the job.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<PregelJobStatus> GetJobStatusAsync(string jobId, CancellationToken token = default)
+        public virtual async Task<PregelJobStatus> GetJobStatusAsync(string jobId,
+            ApiHeaderProperties headers = null, 
+            CancellationToken token = default)
         {
             if (string.IsNullOrWhiteSpace(jobId))
             {
                 throw new ArgumentNullException(nameof(jobId));
             }
             string uri = _apiPath + '/' + jobId;
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -109,15 +118,20 @@ namespace ArangoDBNetStandard.PregelApi
         /// Get the overview of currently running Pregel jobs.
         /// GET /_api/control_pregel
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns>
         /// Returns a list of currently running and recently
         /// finished Pregel jobs without retrieving their results. 
         /// </returns>
-        public virtual async Task<List<PregelJobStatus>> GetAllRunningJobsAsync(CancellationToken token = default)
+        public virtual async Task<List<PregelJobStatus>> GetAllRunningJobsAsync(
+            ApiHeaderProperties headers = null, 
+            CancellationToken token = default)
         {
             string uri = _apiPath;
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -140,12 +154,17 @@ namespace ArangoDBNetStandard.PregelApi
         /// For more information see https://www.arangodb.com/docs/stable/http/pregel.html#cancel-pregel-job-execution
         /// </remarks>
         /// <param name="jobId">The ID of the job.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<string> DeleteJobAsync(string jobId, CancellationToken token = default)
+        public virtual async Task<string> DeleteJobAsync(string jobId,
+            ApiHeaderProperties headers = null, 
+            CancellationToken token = default)
         {
             string uri = _apiPath + '/' + jobId;
-            using (var response = await _transport.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
@@ -16,6 +16,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#abort-transaction
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 1653 if the transaction cannot be aborted.
@@ -23,7 +24,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </exception>
         /// <returns>Response from ArangoDB after aborting a transaction.</returns>
         Task<StreamTransactionResponse> AbortTransaction(string transactionId,
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Begin a stream transaction by POST.
@@ -53,6 +54,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#commit-transaction
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 1653 if the transaction cannot be committed.
@@ -60,18 +62,19 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </exception>
         /// <returns>Response from ArangoDB after committing a transaction.</returns>
         Task<StreamTransactionResponse> CommitTransaction(string transactionId,
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Get currently running transactions.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#get-currently-running-transactions
         /// </remarks>
         /// <returns>Response from ArangoDB with all running transactions.</returns>
         Task<StreamTransactions> GetAllRunningTransactions(
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Get the status of a transaction.
@@ -80,20 +83,22 @@ namespace ArangoDBNetStandard.TransactionApi
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#get-transaction-status
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
         /// <returns>Response from ArangoDB with the status of a transaction.</returns>
         Task<StreamTransactionResponse> GetTransactionStatus(string transactionId,
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// POST a transaction to ArangoDB.
         /// </summary>
         /// <typeparam name="T">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST transaction request.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns>Response from ArangoDB after processing the request.</returns>
         Task<PostTransactionResponse<T>> PostTransactionAsync<T>(PostTransactionBody body,
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -59,14 +59,18 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </remarks>
         /// <typeparam name="T">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST transaction request.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns>Response from ArangoDB after processing the request.</returns>
         public virtual async Task<PostTransactionResponse<T>> PostTransactionAsync<T>(
             PostTransactionBody body,
-            CancellationToken token = default)
+            ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PostAsync(_transactionApiPath, content, token: token).ConfigureAwait(false))
+            using (var response = await _client.PostAsync(_transactionApiPath, 
+                content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
@@ -86,6 +90,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#abort-transaction
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 1653 if the transaction cannot be aborted.
@@ -93,10 +98,12 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </exception>
         /// <returns>Response from ArangoDB after aborting a transaction.</returns>
         public virtual async Task<StreamTransactionResponse> AbortTransaction(string transactionId,
-            CancellationToken token = default)
+            ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string completeAbortTransactionPath = string.Format(_streamTransactionApiPath, transactionId);
-            using (var response = await _client.DeleteAsync(completeAbortTransactionPath, token: token).ConfigureAwait(false))
+            using (var response = await _client.DeleteAsync(completeAbortTransactionPath,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
@@ -156,6 +163,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#commit-transaction
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 1653 if the transaction cannot be committed.
@@ -163,10 +171,13 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </exception>
         /// <returns>Response from ArangoDB after committing a transaction.</returns>
         public virtual async Task<StreamTransactionResponse> CommitTransaction(string transactionId,
-            CancellationToken token = default)
+            ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string completeCommitTransactionPath = string.Format(_streamTransactionApiPath, transactionId);
-            using (var response = await _client.PutAsync(completeCommitTransactionPath, Array.Empty<byte>(), token: token).ConfigureAwait(false))
+            using (var response = await _client.PutAsync(completeCommitTransactionPath,
+                Array.Empty<byte>(),
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
@@ -182,15 +193,18 @@ namespace ArangoDBNetStandard.TransactionApi
         /// <summary>
         /// Get currently running transactions.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <remarks>
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#get-currently-running-transactions
         /// </remarks>
         /// <returns>Response from ArangoDB with all running transactions.</returns>
         public virtual async Task<StreamTransactions> GetAllRunningTransactions(
-            CancellationToken token = default)
+            ApiHeaderProperties headers = null, CancellationToken token = default)
         {
-            using (var response = await _client.GetAsync(_transactionApiPath, token: token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(_transactionApiPath,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
@@ -210,14 +224,17 @@ namespace ArangoDBNetStandard.TransactionApi
         /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#get-transaction-status
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
         /// <returns>Response from ArangoDB with the status of a transaction.</returns>
         public virtual async Task<StreamTransactionResponse> GetTransactionStatus(string transactionId,
-            CancellationToken token = default)
+            ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string getTransactionPath = string.Format(_streamTransactionApiPath, transactionId);
-            using (var response = await _client.GetAsync(getTransactionPath,token:token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(getTransactionPath,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/UserApi/IUserApiClient.cs
+++ b/arangodb-net-standard/UserApi/IUserApiClient.cs
@@ -14,9 +14,11 @@ namespace ArangoDBNetStandard.UserApi
         /// in order to execute this REST call.
         /// </summary>
         /// <param name="body">The request body containing the user information.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PostUserResponse> PostUserAsync(PostUserBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -26,9 +28,11 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="body">The user information used for to replace operation.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PutUserResponse> PutUserAsync(string username, PutUserBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -38,9 +42,11 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="body">The user information used for to replace operation.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PatchUserResponse> PatchUserAsync(string username, PatchUserBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -49,9 +55,11 @@ namespace ArangoDBNetStandard.UserApi
         /// server access level in order to execute this REST call.
         /// </summary>
         /// <param name="username">The name of the user.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetUserResponse> GetUserAsync(string username,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -59,9 +67,11 @@ namespace ArangoDBNetStandard.UserApi
         /// You need Administrate for the server access level in order to execute this REST call.
         /// </summary>
         /// <param name="username">The name of the user.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<DeleteUserResponse> DeleteUserAsync(string username,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -69,9 +79,11 @@ namespace ArangoDBNetStandard.UserApi
         /// You need the Administrate server access level in order to execute this REST call.
         /// Otherwise, you will only get information about yourself.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetUsersResponse> GetUsersAsync(
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -81,12 +93,14 @@ namespace ArangoDBNetStandard.UserApi
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database.</param>
         /// <param name="body">The body of the request containing the access level.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PutAccessLevelResponse> PutDatabaseAccessLevelAsync(
             string username,
             string dbName,
             PutAccessLevelBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -94,11 +108,13 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database to query.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetAccessLevelResponse> GetDatabaseAccessLevelAsync(
             string username,
             string dbName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -109,11 +125,13 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<DeleteAccessLevelResponse> DeleteDatabaseAccessLevelAsync(
             string username,
             string dbName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -122,11 +140,13 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="query">Optional query parameters for the request.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetAccessibleDatabasesResponse> GetAccessibleDatabasesAsync(
             string username,
             GetAccessibleDatabasesQuery query = null,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -137,6 +157,7 @@ namespace ArangoDBNetStandard.UserApi
         /// <param name="dbName">The name of the database.</param>
         /// <param name="collectionName">The name of the collection.</param>
         /// <param name="body">The body of the request containing the access level.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<PutAccessLevelResponse> PutCollectionAccessLevelAsync(
@@ -144,6 +165,7 @@ namespace ArangoDBNetStandard.UserApi
             string dbName,
             string collectionName,
             PutAccessLevelBody body,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -152,12 +174,14 @@ namespace ArangoDBNetStandard.UserApi
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database.</param>
         /// <param name="collectionName">The name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetAccessLevelResponse> GetCollectionAccessLevelAsync(
             string username,
             string dbName,
             string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
 
         /// <summary>
@@ -169,12 +193,14 @@ namespace ArangoDBNetStandard.UserApi
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database.</param>
         /// <param name="collectionName">The name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<DeleteAccessLevelResponse> DeleteCollectionAccessLevelAsync(
             string username,
             string dbName,
             string collectionName,
+            ApiHeaderProperties headers = null,
             CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/UserApi/UserApiClient.cs
+++ b/arangodb-net-standard/UserApi/UserApiClient.cs
@@ -53,13 +53,16 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <exception cref="ApiErrorException">ArangoDB responded with an error.</exception>
         /// <param name="body">The request body containing the user information.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PostUserResponse> PostUserAsync(PostUserBody body,
-            CancellationToken token = default)
+         ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PostAsync(_userApiPath, content, token: token).ConfigureAwait(false))
+            using (var response = await _client.PostAsync(_userApiPath, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -77,14 +80,17 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="body">The user information used for to replace operation.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PutUserResponse> PutUserAsync(string username, PutUserBody body,
-            CancellationToken token = default)
+          ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = _userApiPath + '/' + username;
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PutAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _client.PutAsync(uri, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -102,14 +108,17 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="body">The user information used for to replace operation.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PatchUserResponse> PatchUserAsync(string username, PatchUserBody body,
-            CancellationToken token = default)
+            ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = _userApiPath + '/' + username;
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PatchAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _client.PatchAsync(uri, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -126,13 +135,16 @@ namespace ArangoDBNetStandard.UserApi
         /// server access level in order to execute this REST call.
         /// </summary>
         /// <param name="username">The name of the user.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetUserResponse> GetUserAsync(string username,
-            CancellationToken token = default)
+           ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = _userApiPath + '/' + username;
-            using (var response = await _client.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -148,13 +160,16 @@ namespace ArangoDBNetStandard.UserApi
         /// You need Administrate for the server access level in order to execute this REST call.
         /// </summary>
         /// <param name="username">The name of the user.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteUserResponse> DeleteUserAsync(string username,
-            CancellationToken token = default)
+          ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username);
-            using (var response = await _client.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.DeleteAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -170,13 +185,16 @@ namespace ArangoDBNetStandard.UserApi
         /// You need the Administrate server access level in order to execute this REST call.
         /// Otherwise, you will only get information about yourself.
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetUsersResponse> GetUsersAsync(
-            CancellationToken token = default)
+           ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = _userApiPath;
-            using (var response = await _client.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -194,18 +212,21 @@ namespace ArangoDBNetStandard.UserApi
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database.</param>
         /// <param name="body">The body of the request containing the access level.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PutAccessLevelResponse> PutDatabaseAccessLevelAsync(
             string username,
             string dbName,
-            PutAccessLevelBody body,
+            PutAccessLevelBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
                 + "/database/" + WebUtility.UrlEncode(dbName);
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PutAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _client.PutAsync(uri, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -221,16 +242,19 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database to query.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetAccessLevelResponse> GetDatabaseAccessLevelAsync(
             string username,
-            string dbName,
+            string dbName, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
                 + "/database/" + WebUtility.UrlEncode(dbName);
-            using (var response = await _client.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -249,16 +273,19 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteAccessLevelResponse> DeleteDatabaseAccessLevelAsync(
             string username,
-            string dbName,
+            string dbName, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
                 + "/database/" + WebUtility.UrlEncode(dbName);
-            using (var response = await _client.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.DeleteAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -275,11 +302,12 @@ namespace ArangoDBNetStandard.UserApi
         /// </summary>
         /// <param name="username">The name of the user.</param>
         /// <param name="query">Optional query parameters for the request.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetAccessibleDatabasesResponse> GetAccessibleDatabasesAsync(
             string username,
-            GetAccessibleDatabasesQuery query = null,
+            GetAccessibleDatabasesQuery query = null, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username) + "/database";
@@ -287,7 +315,9 @@ namespace ArangoDBNetStandard.UserApi
             {
                 uri += '?' + query.ToQueryString();
             }
-            using (var response = await _client.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -306,20 +336,23 @@ namespace ArangoDBNetStandard.UserApi
         /// <param name="dbName">The name of the database.</param>
         /// <param name="collectionName">The name of the collection.</param>
         /// <param name="body">The body of the request containing the access level.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PutAccessLevelResponse> PutCollectionAccessLevelAsync(
             string username,
             string dbName,
             string collectionName,
-            PutAccessLevelBody body,
+            PutAccessLevelBody body, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
                 + "/database/" + WebUtility.UrlEncode(dbName) + "/" +
                 WebUtility.UrlEncode(collectionName);
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _client.PutAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _client.PutAsync(uri, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -336,18 +369,21 @@ namespace ArangoDBNetStandard.UserApi
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database.</param>
         /// <param name="collectionName">The name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetAccessLevelResponse> GetCollectionAccessLevelAsync(
             string username,
             string dbName,
-            string collectionName,
+            string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
                 + "/database/" + WebUtility.UrlEncode(dbName) + "/" +
                 WebUtility.UrlEncode(collectionName);
-            using (var response = await _client.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _client.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -367,18 +403,21 @@ namespace ArangoDBNetStandard.UserApi
         /// <param name="username">The name of the user.</param>
         /// <param name="dbName">The name of the database.</param>
         /// <param name="collectionName">The name of the collection.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteAccessLevelResponse> DeleteCollectionAccessLevelAsync(
             string username,
             string dbName,
-            string collectionName,
+            string collectionName, ApiHeaderProperties headers = null,
             CancellationToken token = default)
         {
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
                 + "/database/" + WebUtility.UrlEncode(dbName) + "/" +
                 WebUtility.UrlEncode(collectionName);
-            using (var response = await _client.DeleteAsync(uri,token:token).ConfigureAwait(false))
+            using (var response = await _client.DeleteAsync(uri, 
+                webHeaderCollection:headers?.ToWebHeaderCollection(),
+                token:token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {

--- a/arangodb-net-standard/ViewApi/IViewsApiClient.cs
+++ b/arangodb-net-standard/ViewApi/IViewsApiClient.cs
@@ -15,9 +15,11 @@ namespace ArangoDBNetStandard.ViewApi
         /// regardless of their type. 
         /// GET /_api/view
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetAllViewsResponse> GetAllViewsAsync(
+            ApiHeaderProperties headers = null, 
             CancellationToken token = default);
 
         /// <summary>
@@ -30,39 +32,43 @@ namespace ArangoDBNetStandard.ViewApi
         /// This parameter can be used together with <see cref="LinkProperties.IncludeAllFields"/>
         /// set to false to control if fields with null values are included.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        Task<ViewResponse> PostCreateViewAsync(ViewDetails body, bool ignoreNullValuesOnSerialization = true, CancellationToken token = default);
+        Task<ViewResponse> PostCreateViewAsync(ViewDetails body, bool ignoreNullValuesOnSerialization = true, ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Delete / drop a view
         /// DELETE /_api/view/{view-name}
         /// </summary>
         /// <param name="viewNameOrId">The name or identifier of the view to drop.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<DeleteViewResponse> DeleteViewAsync(string viewNameOrId,
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Get information about a view
         /// GET /_api/view/{view-name}
         /// </summary>
         /// <param name="viewNameOrId">The name or identifier of the view to drop.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetViewResponse> GetViewAsync(string viewNameOrId,
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Get the properties of a view
         /// GET /_api/view/{view-name}/properties
         /// </summary>
         /// <param name="viewNameOrId">The name or identifier of the view to drop.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<GetViewPropertiesResponse> GetViewPropertiesAsync(string viewNameOrId,
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Partially changes properties of a view
@@ -75,10 +81,11 @@ namespace ArangoDBNetStandard.ViewApi
         /// This parameter can be used together with <see cref="LinkProperties.IncludeAllFields"/>
         /// set to false to control if fields with null values are included.
         /// </param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<ViewResponse> PatchViewPropertiesAsync(string viewNameOrId, ViewDetails body, bool ignoreNullValuesOnSerialization = true,
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Changes all properties of a view
@@ -91,10 +98,11 @@ namespace ArangoDBNetStandard.ViewApi
         /// This parameter can be used together with <see cref="LinkProperties.IncludeAllFields"/>
         /// set to false to control if fields with null values are included.
         /// </param>  
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         Task<ViewResponse> PutViewPropertiesAsync(string viewName, ViewDetails body, bool ignoreNullValuesOnSerialization = true,
-            CancellationToken token = default);
+            ApiHeaderProperties headers = null, CancellationToken token = default);
 
         /// <summary>
         /// Renames a view
@@ -102,10 +110,11 @@ namespace ArangoDBNetStandard.ViewApi
         /// </summary>
         /// <param name="viewName">The name of the view.</param>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         /// <remarks>Note: This method is not available in a cluster.</remarks>
         Task<PutRenameViewResponse> PutRenameViewAsync(string viewName, PutRenameViewBody body,
-            CancellationToken token = default);
+           ApiHeaderProperties headers = null, CancellationToken token = default);
     }
 }

--- a/arangodb-net-standard/ViewApi/ViewsApiClient.cs
+++ b/arangodb-net-standard/ViewApi/ViewsApiClient.cs
@@ -51,13 +51,17 @@ namespace ArangoDBNetStandard.ViewApi
         /// regardless of their type. 
         /// GET /_api/view
         /// </summary>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetAllViewsResponse> GetAllViewsAsync(
+            ApiHeaderProperties headers = null, 
             CancellationToken token = default)
         {
             string uri = _apiPath;
-            using (var response = await _transport.GetAsync(uri,token:token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token:token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -78,9 +82,13 @@ namespace ArangoDBNetStandard.ViewApi
         /// This parameter can be used together with <see cref="LinkProperties.IncludeAllFields"/>
         /// set to false to control if fields with null values are included.
         /// </param>  
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-        public virtual async Task<ViewResponse> PostCreateViewAsync(ViewDetails body, bool ignoreNullValuesOnSerialization=true, CancellationToken token = default)
+        public virtual async Task<ViewResponse> PostCreateViewAsync(ViewDetails body, 
+            bool ignoreNullValuesOnSerialization=true, 
+            ApiHeaderProperties headers = null, 
+            CancellationToken token = default)
         {
             string uri = _apiPath;
 
@@ -88,7 +96,10 @@ namespace ArangoDBNetStandard.ViewApi
                                                                                         ignoreNullValues: ignoreNullValuesOnSerialization,
                                                                                         applySerializationOptionsToDictionaryValues: true)).ConfigureAwait(false);
 
-            using (var response = await _transport.PostAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PostAsync(uri, 
+                content, 
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -104,13 +115,17 @@ namespace ArangoDBNetStandard.ViewApi
         /// DELETE /_api/view/{view-name}
         /// </summary>
         /// <param name="viewNameOrId">The name or identifier of the view to drop.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<DeleteViewResponse> DeleteViewAsync(string viewNameOrId,
+            ApiHeaderProperties headers = null, 
             CancellationToken token = default)
         {
             string uri = _apiPath + '/' + viewNameOrId;
-            using (var response = await _transport.DeleteAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.DeleteAsync(uri, 
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -126,13 +141,17 @@ namespace ArangoDBNetStandard.ViewApi
         /// GET /_api/view/{view-name}
         /// </summary>
         /// <param name="viewNameOrId">The name or identifier of the view to drop.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetViewResponse> GetViewAsync(string viewNameOrId,
+            ApiHeaderProperties headers = null, 
             CancellationToken token = default)
         {
             string uri = _apiPath + '/' + viewNameOrId;
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri, 
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -148,13 +167,17 @@ namespace ArangoDBNetStandard.ViewApi
         /// GET /_api/view/{view-name}/properties
         /// </summary>
         /// <param name="viewNameOrId">The name or identifier of the view to drop.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<GetViewPropertiesResponse> GetViewPropertiesAsync(string viewNameOrId,
+            ApiHeaderProperties headers = null, 
             CancellationToken token = default)
         {
             string uri = $"{_apiPath}/{viewNameOrId}/properties";
-            using (var response = await _transport.GetAsync(uri, token: token).ConfigureAwait(false))
+            using (var response = await _transport.GetAsync(uri, 
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -176,17 +199,23 @@ namespace ArangoDBNetStandard.ViewApi
         /// This parameter can be used together with <see cref="LinkProperties.IncludeAllFields"/>
         /// set to false to control if fields with null values are included.
         /// </param>  
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<ViewResponse> PatchViewPropertiesAsync(string viewNameOrId, ViewDetails body, 
-            bool ignoreNullValuesOnSerialization = true, CancellationToken token = default)
+            bool ignoreNullValuesOnSerialization = true, 
+            ApiHeaderProperties headers = null, 
+            CancellationToken token = default)
         {
             string uri = $"{_apiPath}/{viewNameOrId}/properties";
 
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(useCamelCasePropertyNames: true,
                                                                                         ignoreNullValues: ignoreNullValuesOnSerialization,
                                                                                         applySerializationOptionsToDictionaryValues: true)).ConfigureAwait(false);
-            using (var response = await _transport.PatchAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PatchAsync(uri, 
+                content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -208,17 +237,22 @@ namespace ArangoDBNetStandard.ViewApi
         /// This parameter can be used together with <see cref="LinkProperties.IncludeAllFields"/>
         /// set to false to control if fields with null values are included.
         /// </param>  
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<ViewResponse> PutViewPropertiesAsync(string viewName, ViewDetails body, 
-            bool ignoreNullValuesOnSerialization = true, CancellationToken token = default)
+            bool ignoreNullValuesOnSerialization = true, ApiHeaderProperties headers = null, 
+            CancellationToken token = default)
         {
             string uri = $"{_apiPath}/{viewName}/properties";
 
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(useCamelCasePropertyNames: true,
                                                                                         ignoreNullValues: ignoreNullValuesOnSerialization,
                                                                                         applySerializationOptionsToDictionaryValues: true)).ConfigureAwait(false);
-            using (var response = await _transport.PutAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uri,
+                content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(),
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -235,14 +269,17 @@ namespace ArangoDBNetStandard.ViewApi
         /// </summary>
         /// <param name="viewName">The name of the view.</param>
         /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="headers">Headers for the request</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<PutRenameViewResponse> PutRenameViewAsync(string viewName, PutRenameViewBody body,
-            CancellationToken token = default)
+            ApiHeaderProperties headers = null, CancellationToken token = default)
         {
             string uri = $"{_apiPath}/{viewName}/rename";
             var content = await GetContentAsync(body, new ApiClientSerializationOptions(true, true)).ConfigureAwait(false);
-            using (var response = await _transport.PutAsync(uri, content, token: token).ConfigureAwait(false))
+            using (var response = await _transport.PutAsync(uri, content,
+                webHeaderCollection: headers?.ToWebHeaderCollection(), 
+                token: token).ConfigureAwait(false))
             {
                 if (response.IsSuccessStatusCode)
                 {


### PR DESCRIPTION
Add support for overload control in all API requests:
- Add x-arango-max-queue-time-seconds header to ApiHeaderProperties 
- Add ApiHeaderProperties to every API request