### PR TITLE
Fix InvertedIndexConsolidationPolicy. SetgmentsBytesMax type

### DIFF
--- a/arangodb-net-standard/IndexApi/Models/InvertedIndexConsolidationPolicy.cs
+++ b/arangodb-net-standard/IndexApi/Models/InvertedIndexConsolidationPolicy.cs
@@ -30,7 +30,7 @@ namespace ArangoDBNetStandard.IndexApi.Models
         /// segments in bytes.
         /// Default: 5368709120
         /// </summary>
-        public int? SegmentsBytesMax { get; set; }
+        public long? SegmentsBytesMax { get; set; }
 
         /// <summary>
         /// Optional. The maximum number of segments that are evaluated


### PR DESCRIPTION
Fix the property type for SegmentsBytesMax.  `int` cannot contain the default value.  This should help further resolve #470.