### PR TITLE
Fix #484: Use IEnumerable<T> instead of IList<T>.

### DIFF
--- a/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
+++ b/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using ArangoDBNetStandard;
 using ArangoDBNetStandard.DocumentApi.Models;
@@ -185,7 +186,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
             var result = await _adb.Transaction.GetAllRunningTransactions();
 
             // Check for all the running transactions.
-            Assert.Equal(2, result.Transactions.Count);
+            Assert.Equal(2, result.Transactions.Count());
             Assert.Contains(result.Transactions, x => x.State.Equals(StreamTransactionStatus.Running));
         }
 

--- a/arangodb-net-standard/AdminApi/Models/EngineSupports.cs
+++ b/arangodb-net-standard/AdminApi/Models/EngineSupports.cs
@@ -2,10 +2,10 @@
 
 namespace ArangoDBNetStandard.AdminApi.Models
 {
-    public class EngineSupports 
+    public class EngineSupports
     {
         public bool DFDB { get; set; }
-        public IList<string> Indexes { get; set; }
+        public IEnumerable<string> Indexes { get; set; }
         public EngineAlias Aliases { get; set; }
     }
 }

--- a/arangodb-net-standard/AqlFunctionApi/Models/CachedAqlQueryResult.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/CachedAqlQueryResult.cs
@@ -56,6 +56,6 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         /// <summary>
         /// An array of collections/Views the query was using
         /// </summary>
-        public IList<string> DataSources { get; set; }
+        public IEnumerable<string> DataSources { get; set; }
     }
 }

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryBodyOptimizer.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryBodyOptimizer.cs
@@ -18,6 +18,6 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         /// which matches all optimizer rules.
         /// -all disables all rules.
         /// </summary>
-        public IList<string> Rules { get; set; }
+        public IEnumerable<string> Rules { get; set; }
     }
 }

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponse.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponse.cs
@@ -6,7 +6,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
     /// Response from <see cref="AqlFunctionApiClient.PostExplainAqlQueryAsync"/>
     /// See https://www.arangodb.com/docs/stable/http/aql-query.html#explain-an-aql-query
     /// </summary>
-    public class PostExplainAqlQueryResponse:ResponseBase
+    public class PostExplainAqlQueryResponse : ResponseBase
     {
         /// <summary>
         /// The query execution plan.
@@ -18,7 +18,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         /// <see cref="PostExplainAqlQueryBodyOptions.AllPlans"/>
         /// is set to true.
         /// </summary>
-        public IList<PostExplainAqlQueryResponsePlan> Plans { get; set; }
+        public IEnumerable<PostExplainAqlQueryResponsePlan> Plans { get; set; }
 
         /// <summary>
         /// Indicates whether the query results can be 
@@ -31,7 +31,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         /// An array of warnings that occurred during 
         /// optimization or execution plan creation.
         /// </summary>
-        public IList<string> Warnings { get; set; }
+        public IEnumerable<string> Warnings { get; set; }
 
         /// <summary>
         /// Optimizer statistics.

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponseCondition.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponseCondition.cs
@@ -11,6 +11,6 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         public int? Value { get; set; }
         public string VType { get; set; }
         public int? VTypeId { get; set; }
-        public IList<PostExplainAqlQueryResponseCondition> SubNodes { get; set; }
+        public IEnumerable<PostExplainAqlQueryResponseCondition> SubNodes { get; set; }
     }
 }

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponseNode.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponseNode.cs
@@ -9,14 +9,14 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
     public class PostExplainAqlQueryResponseNode
     {
         public string Type { get; set; }
-        public IList<int> Dependencies { get; set; }
+        public IEnumerable<int> Dependencies { get; set; }
         public int? Id { get; set; }
         public decimal? EstimatedCost { get; set; }
         public int? EstimatedNrItems { get; set; }
         public bool? Random { get; set; }
         public PostExplainAqlQueryResponseIndexHint IndexHint { get; set; }
         public PostExplainAqlQueryResponseVariable OutVariable { get; set; }
-        public IList<string> Projections { get; set; }
+        public IEnumerable<string> Projections { get; set; }
         public string Database { get; set; }
         public string Collection { get; set; }
         public bool? Count { get; set; }
@@ -28,7 +28,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         public PostExplainAqlQueryResponseVariable InVariable { get; set; }
         public bool? NeedsGatherNodeSort { get; set; }
         public bool? IndexCoversProjections { get; set; }
-        public IList<PostExplainAqlQueryResponseIndex> Indexes { get; set; }
+        public IEnumerable<PostExplainAqlQueryResponseIndex> Indexes { get; set; }
         public PostExplainAqlQueryResponseCondition Condition { get; set; }
         public bool? Sorted { get; set; }
         public bool? Ascending { get; set; }

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponsePlan.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostExplainAqlQueryResponsePlan.cs
@@ -10,24 +10,24 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         /// <summary>
         /// The array of execution nodes of the plan.
         /// </summary>
-        public IList<PostExplainAqlQueryResponseNode> Nodes { get; set; }
+        public IEnumerable<PostExplainAqlQueryResponseNode> Nodes { get; set; }
 
         /// <summary>
         /// An array of rules the optimizer applied.
         /// </summary>
-        public IList<string> Rules { get; set; }
+        public IEnumerable<string> Rules { get; set; }
 
         /// <summary>
         /// An array of collections used in the query
         /// </summary>
-        public IList<PostExplainAqlQueryResponseCollection> Collections { get; set; }
+        public IEnumerable<PostExplainAqlQueryResponseCollection> Collections { get; set; }
 
         /// <summary>
         /// Array of variables used in the query 
         /// (note: this may contain internal 
         /// variables created by the optimizer)
         /// </summary>
-        public IList<PostExplainAqlQueryResponseVariable> Variables { get; set; }
+        public IEnumerable<PostExplainAqlQueryResponseVariable> Variables { get; set; }
 
         /// <summary>
         /// The total estimated cost for the plan. 

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostParseAqlQueryResponse.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostParseAqlQueryResponse.cs
@@ -16,17 +16,17 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         /// <summary>
         /// Contains the names of the collections that are involved in the query.
         /// </summary>
-        public IList<string> Collections { get; set; }
+        public IEnumerable<string> Collections { get; set; }
 
         /// <summary>
         /// Contains the binding variables involved in the query.
         /// </summary>
-        public IList<string> BindVars { get; set; }
+        public IEnumerable<string> BindVars { get; set; }
 
         /// <summary>
         /// Tree of data nodes providing information about the query.
         /// </summary>
-        public IList<PostParseAqlQueryResponseAstNode> Ast { get; set; }
+        public IEnumerable<PostParseAqlQueryResponseAstNode> Ast { get; set; }
 
         /// <summary>
         /// When the query is invalid this will contain the error number.

--- a/arangodb-net-standard/AqlFunctionApi/Models/PostParseAqlQueryResponseAstNode.cs
+++ b/arangodb-net-standard/AqlFunctionApi/Models/PostParseAqlQueryResponseAstNode.cs
@@ -12,6 +12,6 @@ namespace ArangoDBNetStandard.AqlFunctionApi.Models
         public string Type { get; set; }
         public string Name { get; set; }
         public string Value { get; set; }
-        public IList<PostParseAqlQueryResponseAstNode> SubNodes { get; set; }
+        public IEnumerable<PostParseAqlQueryResponseAstNode> SubNodes { get; set; }
     }
 }

--- a/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsResponse.cs
+++ b/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsResponse.cs
@@ -21,14 +21,14 @@ namespace ArangoDBNetStandard.BulkOperationsApi.Models
         /// (will only contain a value greater zero
         /// for types documents or auto).
         /// </summary>
-        public int? Empty { get; set; } 
+        public int? Empty { get; set; }
 
         /// <summary>
         /// The number of updated/replaced documents
         /// (in case onDuplicate was set to either
         /// update or replace).
         /// </summary>
-        public int? Updated { get; set; } 
+        public int? Updated { get; set; }
 
         /// <summary>
         /// The number of failed but ignored
@@ -43,7 +43,7 @@ namespace ArangoDBNetStandard.BulkOperationsApi.Models
         /// information about which documents could not
         /// be inserted.
         /// </summary>
-        public IList<string> Details { get; set; }
+        public IEnumerable<string> Details { get; set; }
 
         /// <summary>
         /// The HTTP status code.

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -146,7 +146,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         public virtual async Task<PostDocumentsResponse<T>> PostDocumentsAsync<T>(
             string collectionName,
-            IList<T> documents,
+            IEnumerable<T> documents,
             PostDocumentsQuery query = null,
             ApiClientSerializationOptions serializationOptions = null,
             DocumentHeaderProperties headers = null,
@@ -193,7 +193,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         public virtual async Task<PutDocumentsResponse<T>> PutDocumentsAsync<T>(
             string collectionName,
-            IList<T> documents,
+            IEnumerable<T> documents,
             PutDocumentsQuery query = null,
             ApiClientSerializationOptions serializationOptions = null,
             DocumentHeaderProperties headers = null,
@@ -311,7 +311,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
         public virtual async Task<T> GetDocumentAsync<T>(
-            string collectionName, 
+            string collectionName,
             string documentKey,
             DocumentHeaderProperties headers = null,
             CancellationToken token = default)
@@ -367,7 +367,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         public virtual async Task<List<T>> GetDocumentsAsync<T>(
             string collectionName,
-            IList<string> selectors,
+            IEnumerable<string> selectors,
             DocumentHeaderProperties headers = null,
             CancellationToken token = default)
         {
@@ -512,7 +512,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         public virtual async Task<DeleteDocumentsResponse<object>> DeleteDocumentsAsync(
             string collectionName,
-            IList<string> selectors,
+            IEnumerable<string> selectors,
             DeleteDocumentsQuery query = null,
             DocumentHeaderProperties headers = null,
             CancellationToken token = default)
@@ -533,7 +533,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         public virtual async Task<DeleteDocumentsResponse<T>> DeleteDocumentsAsync<T>(
             string collectionName,
-            IList<string> selectors,
+            IEnumerable<string> selectors,
             DeleteDocumentsQuery query = null,
             DocumentHeaderProperties headers = null,
             CancellationToken token = default)
@@ -557,7 +557,7 @@ namespace ArangoDBNetStandard.DocumentApi
                     else
                     {
                         var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                        return await DeserializeJsonFromStreamAsync<DeleteDocumentsResponse<T>>(stream).ConfigureAwait(false); 
+                        return await DeserializeJsonFromStreamAsync<DeleteDocumentsResponse<T>>(stream).ConfigureAwait(false);
                     }
                 }
 
@@ -593,7 +593,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         public virtual async Task<PatchDocumentsResponse<U>> PatchDocumentsAsync<T, U>(
             string collectionName,
-            IList<T> patches,
+            IEnumerable<T> patches,
             PatchDocumentsQuery query = null,
             ApiClientSerializationOptions serializationOptions = null,
             DocumentHeaderProperties headers = null,
@@ -656,13 +656,13 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         public virtual async Task<PatchDocumentsResponse<object>> PatchDocumentsAsync<T>(
           string collectionName,
-          IList<T> patches,
+          IEnumerable<T> patches,
           PatchDocumentsQuery query = null,
           ApiClientSerializationOptions serializationOptions = null,
           DocumentHeaderProperties headers = null,
             CancellationToken token = default)
         {
-            return await PatchDocumentsAsync<T, object>(collectionName,patches,query,serializationOptions,headers, token: token);
+            return await PatchDocumentsAsync<T, object>(collectionName, patches, query, serializationOptions, headers, token: token);
         }
 
         /// <summary>
@@ -696,7 +696,7 @@ namespace ArangoDBNetStandard.DocumentApi
             string documentHandle = WebUtility.UrlEncode(collectionName) +
                 "/" + WebUtility.UrlEncode(documentKey);
 
-            return await PatchDocumentAsync<T, U>(documentHandle, body, query, headers: headers,token: token).ConfigureAwait(false);
+            return await PatchDocumentAsync<T, U>(documentHandle, body, query, headers: headers, token: token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -832,7 +832,7 @@ namespace ArangoDBNetStandard.DocumentApi
             ValidateDocumentId(documentId);
             string uri = _docApiPath + "/" + documentId;
             WebHeaderCollection headerCollection = GetHeaderCollection(headers);
-            using (var response = await _client.HeadAsync(uri, headerCollection,token))
+            using (var response = await _client.HeadAsync(uri, headerCollection, token))
             {
                 return new HeadDocumentResponse
                 {

--- a/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
@@ -70,7 +70,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         Task<PostDocumentsResponse<T>> PostDocumentsAsync<T>(
            string collectionName,
-           IList<T> documents,
+           IEnumerable<T> documents,
            PostDocumentsQuery query = null,
            ApiClientSerializationOptions serializationOptions = null,
            DocumentHeaderProperties headers = null,
@@ -90,7 +90,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         Task<PutDocumentsResponse<T>> PutDocumentsAsync<T>(
            string collectionName,
-           IList<T> documents,
+           IEnumerable<T> documents,
            PutDocumentsQuery query = null,
            ApiClientSerializationOptions serializationOptions = null,
            DocumentHeaderProperties headers = null,
@@ -186,7 +186,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         Task<List<T>> GetDocumentsAsync<T>(
             string collectionName,
-            IList<string> selectors,
+            IEnumerable<string> selectors,
             DocumentHeaderProperties headers = null,
             CancellationToken token = default);
 
@@ -281,7 +281,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         Task<DeleteDocumentsResponse<object>> DeleteDocumentsAsync(
           string collectionName,
-          IList<string> selectors,
+          IEnumerable<string> selectors,
           DeleteDocumentsQuery query = null,
           DocumentHeaderProperties headers = null,
             CancellationToken token = default);
@@ -299,7 +299,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         Task<DeleteDocumentsResponse<T>> DeleteDocumentsAsync<T>(
           string collectionName,
-          IList<string> selectors,
+          IEnumerable<string> selectors,
           DeleteDocumentsQuery query = null,
           DocumentHeaderProperties headers = null,
             CancellationToken token = default);
@@ -334,7 +334,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         Task<PatchDocumentsResponse<U>> PatchDocumentsAsync<T, U>(
           string collectionName,
-          IList<T> patches,
+          IEnumerable<T> patches,
           PatchDocumentsQuery query = null,
           ApiClientSerializationOptions serializationOptions = null,
           DocumentHeaderProperties headers = null,
@@ -369,7 +369,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         Task<PatchDocumentsResponse<object>> PatchDocumentsAsync<T>(
           string collectionName,
-          IList<T> patches,
+          IEnumerable<T> patches,
           PatchDocumentsQuery query = null,
           ApiClientSerializationOptions serializationOptions = null,
           DocumentHeaderProperties headers = null,
@@ -497,7 +497,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// 412: is returned if an “If-Match” header is given and the found document has a different version. The response will also contain the found document’s current revision in the Etag header.
         /// </remarks>
         /// <returns></returns>
-        Task<HeadDocumentResponse> HeadDocumentAsync(string documentId, 
+        Task<HeadDocumentResponse> HeadDocumentAsync(string documentId,
             DocumentHeaderProperties headers = null,
             CancellationToken token = default);
     }

--- a/arangodb-net-standard/TransactionApi/Models/PostTransactionRequestCollections.cs
+++ b/arangodb-net-standard/TransactionApi/Models/PostTransactionRequestCollections.cs
@@ -10,16 +10,16 @@ namespace ArangoDBNetStandard.TransactionApi.Models
         /// <summary>
         /// The list of read-only collections involved in a transaction.
         /// </summary>
-        public IList<string> Read { get; set; }
+        public IEnumerable<string> Read { get; set; }
 
         /// <summary>
         /// The list of write collection involved in a transaction.
         /// </summary>
-        public IList<string> Write { get; set; }
+        public IEnumerable<string> Write { get; set; }
 
         /// <summary>
         /// Collections for which to obtain exclusive locks during a transaction.
         /// </summary>
-        public IList<string> Exclusive { get; set; }
+        public IEnumerable<string> Exclusive { get; set; }
     }
 }

--- a/arangodb-net-standard/TransactionApi/Models/StreamTransactions.cs
+++ b/arangodb-net-standard/TransactionApi/Models/StreamTransactions.cs
@@ -10,6 +10,6 @@ namespace ArangoDBNetStandard.TransactionApi.Models
         /// <summary>
         /// Gets or sets list of all Stream Transactions.
         /// </summary>
-        public IList<Transaction> Transactions { get; set; }
+        public IEnumerable<Transaction> Transactions { get; set; }
     }
 }


### PR DESCRIPTION
Fix #484 by using IEnumerable<T> in place of IList<T>.

I've ended up expanding from the issue description to also update all places we used IList<T> in interfaces and models.

As far as I can tell, this should not be a breaking change because every `IList<T>` is already an `IEnumerable<T>`, but `IEnumerable<T>` allows for greater flexibility in choice of the actual collection type implementations used.