### PR TITLE
Overload CursorApi.PostCursorAsync to execute ad-hoc queries and return only basic statistics

### DIFF
--- a/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
+++ b/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
@@ -18,6 +18,7 @@ namespace ArangoDBNetStandardTest.CursorApi
     public class CursorApiClientTest : IClassFixture<CursorApiClientTestFixture>
     {
         private ICursorApiClient _cursorApi;
+        private readonly string _testCollection;
 
         public class MyModel
         {
@@ -27,6 +28,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         public CursorApiClientTest(CursorApiClientTestFixture fixture)
         {
             _cursorApi = fixture.ArangoDBClient.Cursor;
+            _testCollection = fixture.TestCollection;
         }
 
         [Fact]
@@ -350,6 +352,19 @@ namespace ArangoDBNetStandardTest.CursorApi
             Assert.True(response.HasMore);
 
             var deleteResponse = await _cursorApi.DeleteCursorAsync(response.Id);
+        }
+
+        [Fact]
+        public async Task PostCursorAsync_ShouldSucceed_WhenInsertWithBaseCursorResponse()
+        {
+            string query = "FOR Name IN [\"Jon\",\"Snow\"] INSERT {Name: Name} INTO @@testCollection";
+            var bindVars = new Dictionary<string, object> { ["@testCollection"] = _testCollection };
+
+            CursorResponseBase response = await _cursorApi.PostCursorAsync(query, bindVars);
+
+            Assert.Equal(2, response.Extra.Stats.WritesExecuted);
+            Assert.Equal(HttpStatusCode.Created, response.Code);
+            Assert.False(response.Error);
         }
     }
 }

--- a/arangodb-net-standard.Test/CursorApi/CursorApiClientTestFixture.cs
+++ b/arangodb-net-standard.Test/CursorApi/CursorApiClientTestFixture.cs
@@ -1,4 +1,6 @@
 ﻿using ArangoDBNetStandard;
+using ArangoDBNetStandard.CollectionApi.Models;
+using System;
 using System.Threading.Tasks;
 
 namespace ArangoDBNetStandardTest.CursorApi
@@ -6,6 +8,8 @@ namespace ArangoDBNetStandardTest.CursorApi
     public class CursorApiClientTestFixture : ApiClientTestFixtureBase
     {
         public ArangoDBClient ArangoDBClient { get; private set; }
+
+        public string TestCollection { get; } = "TestCollection";
 
         public CursorApiClientTestFixture()
         {
@@ -21,6 +25,20 @@ namespace ArangoDBNetStandardTest.CursorApi
 
             ArangoDBClient = GetArangoDBClient(dbName);
             await GetVersionAsync(ArangoDBClient);
+
+            try
+            {
+                var response = await ArangoDBClient.Collection.PostCollectionAsync(
+                    new PostCollectionBody
+                    {
+                        Name = TestCollection
+                    });
+            }
+            catch (ApiErrorException ex) when (ex.ApiError.ErrorNum == 1207)
+            {
+                // The collection must exist already, carry on...
+                Console.WriteLine(ex.Message);
+            }
         }
     }
 }

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -152,7 +152,6 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="transactionId">Optional. The stream transaction Id.</param>      
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns></returns>
-
         public virtual async Task<CursorResponseBase> PostCursorAsync(
             string query,
             Dictionary<string, object> bindVars = null,

--- a/arangodb-net-standard/CursorApi/ICursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/ICursorApiClient.cs
@@ -54,6 +54,32 @@ namespace ArangoDBNetStandard.CursorApi
             CancellationToken token = default);
 
         /// <summary>
+        /// Execute an AQL query and return basic statistics.
+        /// </summary>
+        /// <param name="query"></param>
+        /// <param name="bindVars"></param>
+        /// <param name="options"></param>
+        /// <param name="count"></param>
+        /// <param name="batchSize"></param>
+        /// <param name="cache"></param>
+        /// <param name="memoryLimit"></param>
+        /// <param name="ttl"></param>
+        /// <param name="transactionId">Optional. The stream transaction Id.</param>      
+        /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
+        /// <returns></returns>
+        Task<CursorResponseBase> PostCursorAsync(
+            string query,
+            Dictionary<string, object> bindVars = null,
+            PostCursorOptions options = null,
+            bool? count = null,
+            long? batchSize = null,
+            bool? cache = null,
+            long? memoryLimit = null,
+            int? ttl = null,
+            string transactionId = null,
+            CancellationToken token = default);
+
+        /// <summary>
         /// Advances an existing query cursor and gets the next set of results.
         /// Replaces <see cref="PutCursorAsync{T}(string, CancellationToken)"/>
         /// </summary>

--- a/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
+++ b/arangodb-net-standard/CursorApi/Models/CursorResponse.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Net;
 
 namespace ArangoDBNetStandard.CursorApi.Models
 {
@@ -7,59 +6,11 @@ namespace ArangoDBNetStandard.CursorApi.Models
     /// Response from ArangoDB when creating a new cursor.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class CursorResponse<T> : ICursorResponse<T>
+    public class CursorResponse<T> : CursorResponseBase, ICursorResponse<T>
     {
-        /// <summary>
-        /// Indicates whether an error occurred
-        /// </summary>
-        /// <remarks>
-        /// Note that in cases where an error occurs, the ArangoDBNetStandard
-        /// client will throw an <see cref="ApiErrorException"/> rather than
-        /// populating this property. A try/catch block should be used instead
-        /// for any required error handling.
-        /// </remarks>
-        public bool Error { get; set; }
-
-        /// <summary>
-        /// the total number of result documents available
-        /// (only available if the query was executed with the count attribute set)
-        /// </summary>
-        public long Count { get; set; }
-
-        /// <summary>
-        /// The HTTP status code
-        /// </summary>
-        public HttpStatusCode Code { get; set; }
-
-        /// <summary>
-        /// Optional object with extra information about the query result contained
-        /// in its <see cref="CursorResponseExtra.Stats"/> sub-attribute.
-        /// For data-modification queries, the sub-attribute will contain the number of
-        /// modified documents and the number of documents that could not be modified
-        /// due to an error (if ignoreErrors query option is specified).
-        /// </summary>
-        public CursorResponseExtra Extra { get; set; }
-
-        /// <summary>
-        /// Indicates whether the query result was served from the query cache or not.
-        /// If the query result is served from the query cache, the extra return attribute
-        /// will not contain any stats sub-attribute and no profile sub-attribute.
-        /// </summary>
-        public bool Cached { get; set; }
-
-        /// <summary>
-        /// Whether there are more results available for the cursor on the server.
-        /// </summary>
-        public bool HasMore { get; set; }
-
         /// <summary>
         /// Result documents (might be empty if query has no results).
         /// </summary>
         public IEnumerable<T> Result { get; set; }
-
-        /// <summary>
-        /// ID of temporary cursor created on the server (optional).
-        /// </summary>
-        public string Id { get; set; }
     }
 }

--- a/arangodb-net-standard/CursorApi/Models/CursorResponseBase.cs
+++ b/arangodb-net-standard/CursorApi/Models/CursorResponseBase.cs
@@ -1,0 +1,58 @@
+﻿using System.Net;
+
+namespace ArangoDBNetStandard.CursorApi.Models
+{
+    /// <summary>
+    /// Base part of the cursor response from ArangoDB not containing a generic result.
+    /// </summary>
+    public class CursorResponseBase
+    {
+        /// <summary>
+        /// Indicates whether an error occurred
+        /// </summary>
+        /// <remarks>
+        /// Note that in cases where an error occurs, the ArangoDBNetStandard
+        /// client will throw an <see cref="ApiErrorException"/> rather than
+        /// populating this property. A try/catch block should be used instead
+        /// for any required error handling.
+        /// </remarks>
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// the total number of result documents available
+        /// (only available if the query was executed with the count attribute set)
+        /// </summary>
+        public long Count { get; set; }
+
+        /// <summary>
+        /// The HTTP status code
+        /// </summary>
+        public HttpStatusCode Code { get; set; }
+
+        /// <summary>
+        /// Optional object with extra information about the query result contained
+        /// in its <see cref="CursorResponseExtra.Stats"/> sub-attribute.
+        /// For data-modification queries, the sub-attribute will contain the number of
+        /// modified documents and the number of documents that could not be modified
+        /// due to an error (if ignoreErrors query option is specified).
+        /// </summary>
+        public CursorResponseExtra Extra { get; set; }
+
+        /// <summary>
+        /// Indicates whether the query result was served from the query cache or not.
+        /// If the query result is served from the query cache, the extra return attribute
+        /// will not contain any stats sub-attribute and no profile sub-attribute.
+        /// </summary>
+        public bool Cached { get; set; }
+
+        /// <summary>
+        /// Whether there are more results available for the cursor on the server.
+        /// </summary>
+        public bool HasMore { get; set; }
+
+        /// <summary>
+        /// ID of temporary cursor created on the server (optional).
+        /// </summary>
+        public string Id { get; set; }
+    }
+}


### PR DESCRIPTION
I propose overloading **CursorApi.PostCursorAsync** to enable the execution of ad-hoc queries and return only basic statistics.