### PR TITLE
Fixes #494 CollectionApiClient.PostCollectionAsync fails on 3.12.x if…

### DIFF
--- a/arangodb-net-standard/CollectionApi/Models/CollectionKeyOptions.cs
+++ b/arangodb-net-standard/CollectionApi/Models/CollectionKeyOptions.cs
@@ -17,13 +17,13 @@
         /// Increment value for autoincrement key generator.
         /// Not used for other key generator types.
         /// </summary>
-        public long Increment { get; set; }
+        public long? Increment { get; set; }
 
         /// <summary>
         /// Initial offset value for autoincrement key generator.
         /// Not used for other key generator types.
         /// </summary>
-        public long Offset { get; set; }
+        public long? Offset { get; set; }
 
         /// <summary>
         /// Apecifies the type of the key generator.


### PR DESCRIPTION
… key type isn't autoincrement

Setting Offset and Increment to null by default will exclude them from the JSON.

Fixes #494 