### PR TITLE
Mark PostTransactionAsync as deprecated since ArangoDB 3.12

### DIFF
--- a/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
+++ b/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
@@ -2,7 +2,7 @@
 using ArangoDBNetStandard.Serialization;
 using ArangoDBNetStandard.TransactionApi.Models;
 using ArangoDBNetStandardTest.Serialization.Models;
-using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -184,7 +184,7 @@ namespace ArangoDBNetStandardTest.Serialization
             var serialization = new JsonNetApiClientSerialization();
 
             byte[] jsonBytes = serialization.Serialize(body, new ApiClientSerializationOptions(
-                useCamelCasePropertyNames: true, 
+                useCamelCasePropertyNames: true,
                 ignoreNullValues: true,
                 applySerializationOptionsToDictionaryValues: true));
 
@@ -197,6 +197,7 @@ namespace ArangoDBNetStandardTest.Serialization
         }
 
         [Fact]
+        [Obsolete]
         public void Serialize_ShouldNotCamelCaseParams_WhenSerializingPostTransactionBody()
         {
             var body = new PostTransactionBody
@@ -223,6 +224,7 @@ namespace ArangoDBNetStandardTest.Serialization
 
 
         [Fact]
+        [Obsolete]
         public void Serialize_ShouldCamelCaseParams_WhenSerializingPostTransactionBodyWithDictionaryOption()
         {
             var body = new PostTransactionBody
@@ -268,6 +270,7 @@ namespace ArangoDBNetStandardTest.Serialization
         }
 
         [Fact]
+        [Obsolete]
         public void Serialize_ShouldNotIgnoreNull_WhenSerializingPostTransactionBody()
         {
             var body = new PostTransactionBody

--- a/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
+++ b/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using ArangoDBNetStandard;
@@ -250,6 +251,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// Tests that a post JS transaction succeeds.
         /// </summary>
         [Fact]
+        [Obsolete]
         public async Task PostTransaction_ShouldSucceed()
         {
             await _adb.Document.PostDocumentAsync(
@@ -295,6 +297,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 10 missing/invalid action definition for transaction.</exception>
         [Fact]
+        [Obsolete]
         public async Task PostTransaction_ShouldThrow_WhenFunctionDefinitionHasSyntaxErrors()
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
@@ -314,6 +317,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 10 missing/invalid collections definition for transaction.</exception>
         [Fact]
+        [Obsolete]
         public async Task PostTransaction_ShouldThrow_WhenWriteCollectionIsNotDeclared()
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>

--- a/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using ArangoDBNetStandard.TransactionApi.Models;
 
@@ -87,12 +88,17 @@ namespace ArangoDBNetStandard.TransactionApi
             CancellationToken token = default);
 
         /// <summary>
-        /// POST a transaction to ArangoDB.
+        /// [DEPRECATED] POST a JavaScript Transaction to ArangoDB.
         /// </summary>
+        /// <remarks>
+        /// JavaScript Transactions are deprecated from v3.12.0 onward and will be removed in a future version.
+        /// https://docs.arangodb.com/stable/release-notes/version-3.12/incompatible-changes-in-3-12/#javascript-transactions-deprecated
+        /// </remarks>
         /// <typeparam name="T">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST transaction request.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns>Response from ArangoDB after processing the request.</returns>
+        [Obsolete("JavaScript Transactions are deprecated in ArangoDB 3.12, use Stream Transactions instead.")]
         Task<PostTransactionResponse<T>> PostTransactionAsync<T>(PostTransactionBody body,
             CancellationToken token = default);
     }

--- a/arangodb-net-standard/TransactionApi/Models/PostTransactionBody.cs
+++ b/arangodb-net-standard/TransactionApi/Models/PostTransactionBody.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace ArangoDBNetStandard.TransactionApi.Models
 {
     /// <summary>
     /// Represents information required to make a transaction request to ArangoDB.
     /// </summary>
+    [Obsolete]
     public class PostTransactionBody
     {
         /// <summary>

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -61,6 +61,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// <param name="body">Object containing information to submit in the POST transaction request.</param>
         /// <param name="token">A CancellationToken to observe while waiting for the task to complete or to cancel the task.</param>
         /// <returns>Response from ArangoDB after processing the request.</returns>
+        [Obsolete]
         public virtual async Task<PostTransactionResponse<T>> PostTransactionAsync<T>(
             PostTransactionBody body,
             CancellationToken token = default)


### PR DESCRIPTION
fix #496 