### PR TITLE
Update propertyname of ComputeOn

### DIFF
--- a/arangodb-net-standard/CollectionApi/Models/ComputedValue.cs
+++ b/arangodb-net-standard/CollectionApi/Models/ComputedValue.cs
@@ -40,7 +40,7 @@ namespace ArangoDBNetStandard.CollectionApi.Models
         /// and "replace". 
         /// The default is ["insert", "update", "replace"]
         /// </summary>
-        public List<string> ComputedOn { get; set; } = new List<string>() { "insert", "update", "replace" };
+        public List<string> ComputeOn { get; set; } = new List<string>() { "insert", "update", "replace" };
 
         /// <summary>
         /// Optional. Indicates whether the target attribute shall 


### PR DESCRIPTION
This class should be consistent with the Javascript interface described in the docs as this is directly serialized. The current name causes the property to be ignored on the backend.

C.f. https://docs.arangodb.com/3.12/concepts/data-structure/documents/computed-values/#javascript-api