### PR TITLE
Parse inverted indexes field names into array of strings

### DIFF
--- a/arangodb-net-standard.Test/IndexApi/IndexFieldsConverterTest.cs
+++ b/arangodb-net-standard.Test/IndexApi/IndexFieldsConverterTest.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ArangoDBNetStandard.IndexApi.Converters;
+using ArangoDBNetStandard.IndexApi.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace ArangoDBNetStandardTest.IndexApi
+{
+    public class IndexFieldsConverterTest
+    {
+        private readonly JsonSerializerSettings _settings;
+
+        public IndexFieldsConverterTest()
+        {
+            _settings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                NullValueHandling = NullValueHandling.Include
+            };
+            _settings.Converters.Add(new IndexFieldsConverter());
+        }
+
+        [Fact]
+        public void ReadJson_ShouldDeserializeStringArray_WhenJsonIsSimpleStringArray()
+        {
+            // Arrange
+            var json = """
+            {
+                "fields": ["field1", "field2", "field3"]
+            }
+            """;
+
+            // Act
+            var result = JsonConvert.DeserializeObject<TestIndexResponse>(json, _settings);
+
+            // Assert
+            Assert.NotNull(result.Fields);
+            Assert.Equal(3, result.Fields.Count());
+            Assert.Contains("field1", result.Fields);
+            Assert.Contains("field2", result.Fields);
+            Assert.Contains("field3", result.Fields);
+        }
+
+        [Fact]
+        public void ReadJson_ShouldExtractNameFields_WhenJsonIsObjectArrayWithNameProperty()
+        {
+            // Arrange
+            var json = """
+            {
+                "fields": [
+                    {"name": "field1", "type": "string"},
+                    {"name": "field2", "type": "number"},
+                    {"name": "field3", "type": "boolean"}
+                ]
+            }
+            """;
+
+            // Act
+            var result = JsonConvert.DeserializeObject<TestIndexResponse>(json, _settings);
+
+            // Assert
+            Assert.NotNull(result.Fields);
+            Assert.Equal(3, result.Fields.Count());
+            Assert.Contains("field1", result.Fields);
+            Assert.Contains("field2", result.Fields);
+            Assert.Contains("field3", result.Fields);
+        }
+
+        [Fact]
+        public void ReadJson_ShouldFilterOutNullNames_WhenObjectArrayHasNullNameValues()
+        {
+            // Arrange
+            var json = """
+            {
+                "fields": [
+                    {"name": "field1", "type": "string"},
+                    {"name": null, "type": "number"},
+                    {"name": "field3", "type": "boolean"}
+                ]
+            }
+            """;
+
+            // Act
+            var result = JsonConvert.DeserializeObject<TestIndexResponse>(json, _settings);
+
+            // Assert
+            Assert.NotNull(result.Fields);
+            Assert.Equal(2, result.Fields.Count());
+            Assert.Contains("field1", result.Fields);
+            Assert.Contains("field3", result.Fields);
+            Assert.DoesNotContain(null, result.Fields);
+        }
+
+        [Fact]
+        public void ReadJson_ShouldHandleEmptyArray()
+        {
+            // Arrange
+            var json = """
+            {
+                "fields": []
+            }
+            """;
+
+            // Act
+            var result = JsonConvert.DeserializeObject<TestIndexResponse>(json, _settings);
+
+            // Assert
+            Assert.NotNull(result.Fields);
+            Assert.Empty(result.Fields);
+        }
+
+        [Fact]
+        public void ReadJson_ShouldThrowJsonSerializationException_WhenTokenIsNotArray()
+        {
+            // Arrange
+            var json = """
+            {
+                "fields": "not an array"
+            }
+            """;
+
+            // Act & Assert
+            Assert.Throws<JsonSerializationException>(() => 
+                JsonConvert.DeserializeObject<TestIndexResponse>(json, _settings));
+        }
+
+        [Fact]
+        public void ReadJson_ShouldReturnNull_WhenTokenIsNull()
+        {
+            // Arrange
+            var json = """
+            {
+                "fields": null
+            }
+            """;
+
+            // Act
+            var result = JsonConvert.DeserializeObject<TestIndexResponse>(json, _settings);
+
+            // Assert
+            Assert.Null(result.Fields);
+        }
+
+        [Fact]
+        public void ReadJson_ShouldHandleMixedObjectAndStringArray_WhenFirstElementIsNotObject()
+        {
+            // Arrange - this tests the case where we have an array but the first element is not an object
+            var json = """
+            {
+                "fields": ["field1", "field2"]
+            }
+            """;
+
+            // Act
+            var result = JsonConvert.DeserializeObject<TestIndexResponse>(json, _settings);
+
+            // Assert
+            Assert.NotNull(result.Fields);
+            Assert.Equal(2, result.Fields.Count());
+            Assert.Contains("field1", result.Fields);
+            Assert.Contains("field2", result.Fields);
+        }
+
+        [Fact]
+        public void WriteJson_ShouldSerializeToStringArray()
+        {
+            // Arrange
+            var indexResponse = new TestIndexResponse
+            {
+                Fields = new[] { "field1", "field2", "field3" }
+            };
+
+            // Act
+            var json = JsonConvert.SerializeObject(indexResponse, _settings);
+
+            // Assert
+            Assert.Contains("\"fields\":[\"field1\",\"field2\",\"field3\"]", json);
+        }
+
+        [Fact]
+        public void WriteJson_ShouldSerializeNullFields()
+        {
+            // Arrange
+            var indexResponse = new TestIndexResponse
+            {
+                Fields = null
+            };
+
+            // Act
+            var json = JsonConvert.SerializeObject(indexResponse, _settings);
+
+            // Assert
+            Assert.Contains("\"fields\":null", json);
+        }
+
+        [Fact]
+        public void WriteJson_ShouldSerializeEmptyFields()
+        {
+            // Arrange
+            var indexResponse = new TestIndexResponse
+            {
+                Fields = new string[0]
+            };
+
+            // Act
+            var json = JsonConvert.SerializeObject(indexResponse, _settings);
+
+            // Assert
+            Assert.Contains("\"fields\":[]", json);
+        }
+
+        [Fact]
+        public void RoundTrip_ShouldPreserveStringArrayData()
+        {
+            // Arrange
+            var originalFields = new List<string> { "field1", "field2", "field3" };
+            var indexResponse = new TestIndexResponse { Fields = originalFields };
+
+            // Act
+            var json = JsonConvert.SerializeObject(indexResponse, _settings);
+            var deserializedResponse = JsonConvert.DeserializeObject<TestIndexResponse>(json, _settings);
+
+            // Assert
+            Assert.NotNull(deserializedResponse.Fields);
+            Assert.Equal(originalFields.Count, deserializedResponse.Fields.Count());
+            Assert.True(originalFields.SequenceEqual(deserializedResponse.Fields));
+        }
+
+        // Helper class for testing
+        private class TestIndexResponse
+        {
+            [JsonConverter(typeof(IndexFieldsConverter))]
+            public IEnumerable<string> Fields { get; set; }
+        }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Converters/IndexFieldsConverter.cs
+++ b/arangodb-net-standard/IndexApi/Converters/IndexFieldsConverter.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ArangoDBNetStandard.IndexApi.Converters
+{
+    public class IndexFieldsConverter : JsonConverter<IEnumerable<string>>
+    {
+        public override IEnumerable<string> ReadJson(JsonReader reader, Type objectType, IEnumerable<string> existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var token = JToken.Load(reader);
+            if (token.Type == JTokenType.Array)
+            {
+                var first = token.First;
+                if (first != null && first.Type == JTokenType.Object)
+                {
+                    // This is an array of objects, extract name properties
+                    return token.Select(o => o["name"]?.ToString()).Where(n => !string.IsNullOrEmpty(n));
+                }
+                else
+                {
+                    // This is an array of strings
+                    return token.ToObject<List<string>>();
+                }
+            }
+            else if (token.Type == JTokenType.Null)
+            {
+                return null;
+            }
+
+            throw new JsonSerializationException("Unexpected token type for index fields.");
+        }
+
+        public override void WriteJson(JsonWriter writer, IEnumerable<string> value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WriteStartArray();
+                foreach (var item in value)
+                {
+                    writer.WriteValue(item);
+                }
+                writer.WriteEndArray();
+            }
+        }
+    }
+}

--- a/arangodb-net-standard/IndexApi/Models/IndexResponseBase.cs
+++ b/arangodb-net-standard/IndexApi/Models/IndexResponseBase.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using ArangoDBNetStandard.IndexApi.Converters;
+using Newtonsoft.Json;
 
 namespace ArangoDBNetStandard.IndexApi.Models
 {
@@ -11,7 +13,7 @@ namespace ArangoDBNetStandard.IndexApi.Models
         public string Id { get; set; }
 
         public string Name { get; set; }
-
+        [JsonConverter(typeof(IndexFieldsConverter))]
         public IEnumerable<string> Fields { get; set; }
 
         public bool? Sparse { get; set; }


### PR DESCRIPTION
Right now IndexApiClient.GetAllCollectionIndexesAsync fails with deserealization issue. 

It happens because for persistent indexes only field names are stored and returned as array of strings.
For inverted indexes it's different: there is an object with properties.

My goal was to fix deserealization issue to allow my work to continue as we want to use inverted indexes in our database and using mentioned method for database schema verify.


I do know there is InvertedIndexField model but don't think adding a major change to interface is what is needed for this issue.